### PR TITLE
Cauli instances never been deallocated

### DIFF
--- a/Cauli.xcodeproj/project.pbxproj
+++ b/Cauli.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1F18B1A4210EF9F500CEDD42 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18B1A2210EF9F500CEDD42 /* Storage.swift */; };
 		1F18B1A5210EF9F500CEDD42 /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18B1A3210EF9F500CEDD42 /* MemoryStorage.swift */; };
+		1F644F4A211B620B004C4271 /* WeakReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F644F49211B620B004C4271 /* WeakReference.swift */; };
 		1F7BF22C20F77B0A0023D219 /* CauliURLProtocolDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22B20F77B0A0023D219 /* CauliURLProtocolDelegate.swift */; };
 		1F7BF22E20F77B6C0023D219 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22D20F77B6C0023D219 /* Record.swift */; };
 		1F7BF23020F790F50023D219 /* URLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22F20F790F50023D219 /* URLSessionConfiguration.swift */; };
@@ -33,6 +34,7 @@
 /* Begin PBXFileReference section */
 		1F18B1A2210EF9F500CEDD42 /* Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		1F18B1A3210EF9F500CEDD42 /* MemoryStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
+		1F644F49211B620B004C4271 /* WeakReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReference.swift; sourceTree = "<group>"; };
 		1F7BF22B20F77B0A0023D219 /* CauliURLProtocolDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CauliURLProtocolDelegate.swift; sourceTree = "<group>"; };
 		1F7BF22D20F77B6C0023D219 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		1F7BF22F20F790F50023D219 /* URLSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionConfiguration.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 				1F7BF22F20F790F50023D219 /* URLSessionConfiguration.swift */,
 				1F18B1A2210EF9F500CEDD42 /* Storage.swift */,
 				1F18B1A3210EF9F500CEDD42 /* MemoryStorage.swift */,
+				1F644F49211B620B004C4271 /* WeakReference.swift */,
 			);
 			path = Cauli;
 			sourceTree = "<group>";
@@ -226,6 +229,7 @@
 				1F18B1A5210EF9F500CEDD42 /* MemoryStorage.swift in Sources */,
 				1F7BF23020F790F50023D219 /* URLSessionConfiguration.swift in Sources */,
 				1F7BF22E20F77B6C0023D219 /* Record.swift in Sources */,
+				1F644F4A211B620B004C4271 /* WeakReference.swift in Sources */,
 				1F7BF22C20F77B0A0023D219 /* CauliURLProtocolDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Cauli/CauliURLProtocol.swift
+++ b/Cauli/CauliURLProtocol.swift
@@ -12,17 +12,20 @@ internal class CauliURLProtocol: URLProtocol {
     
     private var executingURLSession: URLSession!
     
-    private static var delegates: [CauliURLProtocolDelegate] = []
+    private static var weakDelegates: [WeakReference<CauliURLProtocolDelegate>] = []
+    private static var delegates: [CauliURLProtocolDelegate] {
+        return weakDelegates.filter({ $0.value != nil }).compactMap({ $0.value as? CauliURLProtocolDelegate })
+    }
     
     private var record: Record
     private var dataTask: URLSessionDataTask?
     
     internal static func add(delegate: CauliURLProtocolDelegate) {
-        delegates.append(delegate)
+        weakDelegates.append(WeakReference(delegate))
     }
     
     internal static func remove(delegate: CauliURLProtocolDelegate) {
-        delegates = delegates.filter { $0 !== delegate}
+        weakDelegates = weakDelegates.filter { $0.value !== delegate}
     }
     
     override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {

--- a/Cauli/WeakReference.swift
+++ b/Cauli/WeakReference.swift
@@ -1,0 +1,17 @@
+//
+//  WeakReference.swift
+//  Cauli
+//
+//  Created by Cornelius Horstmann on 08.08.18.
+//  Copyright © 2018 brototyp.de. All rights reserved.
+//
+
+import Foundation
+
+internal class WeakReference<T> {
+    weak var value: AnyObject?
+    
+    init(_ value: T?) {
+        self.value = value as AnyObject
+    }
+}


### PR DESCRIPTION
Since the CauliURLProtocol holds a strong reference to it's delegate and the Cauli instance only deregistered itself upon deallocation the cauli instances were never deallocated.

I created a wrapper type, wrapping the delegates and holding them weakly.