### PR TITLE
Changed the setup function to be a static function

### DIFF
--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -26,7 +26,7 @@ public class Cauli {
 extension Cauli {
     // We use this static property here to ensure the actual setup
     // is performed only once
-    private static let setup: Void = {
+    private static let _setup: Void = {
         URLProtocol.registerClass(CauliURLProtocol.self)
         URLSessionConfiguration.cauliSwizzleDefaultSessionConfigurationGetter()
         return
@@ -35,8 +35,8 @@ extension Cauli {
     /// Performs initial Cauli setup and hooks itself into the [URL Loading System](https://developer.apple.com/documentation/foundation/url_loading_system).
     ///
     /// Call this as early as possible, preferred in the [application:didFinishLaunchingWithOptions:](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application).
-    public func setup() {
-        _ = setup
+    public static func setup() {
+        _ = _setup
     }
 }
 


### PR DESCRIPTION
The setup function was an instance function. I changed it to be a static function and fixed the collision with the static setup property.