### PR TITLE
Adding a basic jazzy configuration and some additional documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ playground.xcworkspace
 /*.gcno
 
 # End of https://www.gitignore.io/api/osx,swift,xcode,objective-c
+/docs/generated

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,6 @@
+module: Cauli
+author_url: https://cauli.works
+github_url: https://github.com/cauliframework/cauli
+output: docs/generated
+theme: fullwidth
+documentation: docs/guides/*.md

--- a/Cauli.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Cauli.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,79 +1,53 @@
-# Cauli
+# ![Cauli](https://cauli.works/logo.png)
+
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Cauli.svg?style=flat-square)](https://cocoapods.org/pods/Cauli) 
+[![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/cauliframework/cauli/blob/develop/LICENSE)
 
 Cauli is a network debugging framework featuring a plugin infrastructure to hook into selected request and responses as well as recording and displaying performed requests.
 
-**Cauli is designed for developing purposes. Even if it doesn't use any private API we recommend against using it in a production environment**
+**Cauli is designed for developing purposes. Even if it doesn't use any private API we recommend against using it in a production environment.**
 
-## Installation
-### [CocoaPods](https://cocoapods.org)
+## Getting Started
+
+### Installation
+#### [CocoaPods](https://cocoapods.org)
 
 Use the following in your Podfile.
 
-```
+```ruby
 pod 'Cauli', '~> 1.0'
 ```
 
-Then run `pod install`. In every file you want to use Cauli, don't forget to import the framework with `import Cauli`.
+Then run `pod install`. 
 
-### Carthage
-
-// TODO: Update before public release
+#### Carthage
 
 [Carthage](https://github.com/Carthage/Carthage) is a non intrusive way to install Cauli to your project. It makes no changes to your Xcode project and workspace. Add the following to your Cartfile:
 
-```
-github "organization/cauli"
+```swift
+github "cauliframework/cauli"
 ```
 
-## Usage
 ### Setup
 
-Before Cauli can be used the setup function has to be called. To let Cauli inspect all requests it is important to do this before any `URLSession` is created. We recommend to setup Cauli in the `application(:, didFinishLaunchingWithOptions:)` in your `AppDelegate`.
+Add an `import Cauli` to your `AppDelegate` and call the `run` function on the shared instace in the `application(:, didFinishLaunchingWithOptions:)`.
 
-```Swift
+```swift
 import Cauli
 
 public class AppDelegate: UIApplicationDelegate {
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        Cauli.setup()
+        Cauli.shared.run()
         // perform your usual application setup
         return true
     }
 }
 ```
 
-### Creating a Cauli instance
-
-Without a Cauli instance no network requests will be intercepted. Once you create a Cauli instace all requests will be recorded and processed by every Floret until the instance is deallocated.
-
-// TODO: Explain Floret usage
-
-```Swift
-let florets = [ExampleFloretOne(), ExampleFloretTwo()]
-let cauli = Cauli(florets)
-```
-
-### Querying the storage
-
-Every Cauli instance has it's own `storage`. The storage holds onto `Record`s. Each record contains one network request and it's response. In order to display and inspect the records you can query the storage.
-
-```Swift
-// get the first 10 records
-let records = cauli.storage.records(count: 10, after: nil)
-
-// get the next 10 records
-let nextRecords = cauli.storage.records(count: 10, after: records.last!)
-```
-
-## Details
-
-### Architecture
-Cauli will hook into the [URL Loading System](https://developer.apple.com/documentation/foundation/url_loading_system) by register a custom [URLProtocol](https://developer.apple.com/documentation/foundation/urlprotocol) and swizzling the [URLSessionConfiguration.default](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411560-default) with one, where the [protocolClasses](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411050-protocolclasses) contain the custom [URLProtocol](https://developer.apple.com/documentation/foundation/urlprotocol).
-
-Therefore it's recommended to call `Cauli.setup()` as soon as possible, preferred in the [`application:didFinishLaunchingWithOptions:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application?language=objc) to ensure that all network requests can be intercepted.
+This will configure Cauli to hook into every request, setup a some plugins (TODO: List the plugins) and configures a shake gesture for the Cauli UI.
 
 ## Contributing
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Please read [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## License
 Cauli is available under the [MIT license](LICENSE).

--- a/docs/guides/Architecture.md
+++ b/docs/guides/Architecture.md
@@ -1,0 +1,4 @@
+# Architecture
+Cauli will hook into the [URL Loading System](https://developer.apple.com/documentation/foundation/url_loading_system) by register a custom [URLProtocol](https://developer.apple.com/documentation/foundation/urlprotocol) and swizzling the [URLSessionConfiguration.default](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411560-default) with one, where the [protocolClasses](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411050-protocolclasses) contain the custom [URLProtocol](https://developer.apple.com/documentation/foundation/urlprotocol).
+
+Therefore it's recommended to create your Cauli instance as soon as possible, preferred in the [`application:didFinishLaunchingWithOptions:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application?language=objc) to ensure that all network requests can be intercepted.

--- a/docs/guides/Configuring Cauli.md
+++ b/docs/guides/Configuring Cauli.md
@@ -1,0 +1,32 @@
+# Configuring Cauli
+
+To get started Cauli offers a shared instance already setup and ready to use but you can instantiate and configure your own.
+
+## Instantiating Cauli
+
+Please make sure you create your Cauli instance as early as possible, especially before any request is started so Cauli can intercept every request. If you don't want to start Cauli at the beginning just don't call the `run` function. Check the [Architecture](Architecture) for more details.
+ 
+```swift
+let cauli = Cauli([ InspectorFloret() ], configuration: Configuration(isShakeGestureEnabled: false))
+```
+
+Please check the [Docs](https://cauli.works/docs/Structs.html#/s:5Cauli13ConfigurationV) for all configuration options.
+
+## Start / Stop Cauli
+
+```swift
+cauli.run()
+cauli.pause()
+```
+
+## Manually Display the Cauli UI
+
+If you don't want to use the shake gesture you can display the Cauli UI manually.
+
+```swift
+// Disable the shake gesture using the Configuration
+let cauli = Cauli([ InspectorFloret() ], configuration: Configuration(isShakeGestureEnabled: false))
+
+// Create the Cauli ViewController to display it manually
+let cauliViewController = cauli.viewController()
+```

--- a/docs/guides/Writing Your Own Plugin.md
+++ b/docs/guides/Writing Your Own Plugin.md
@@ -1,0 +1,30 @@
+# Writing your own Plugin
+
+You can write your own plugin if you want to process requests before they get send or responses after they got received.
+
+## Implementing the `Floret` protocol
+
+```swift
+protocol Floret {
+    
+    /// The name of your floret so we can display it in a list.
+    var name: String? { get }
+    
+    // So we can show switches for the Florets in the Cauli UI.
+    // There is no need to act on this bool. If it is disabled, the 
+    // `willRequest` and `didRespond` functions just aren't called anymore.
+    var enabled: Bool { get set }
+    
+    // Return a ViewController here if you want to or nil if you don't have any UI at all.
+    func viewController(_ cauli: Cauli) -> UIViewController?
+    
+    // These are the two functions that you can use to manipulate a request before it will be sent ...
+    func willRequest(_ record: Record) -> Record
+    // ... and the response after it is received.
+    func didRespond(_ record: Record) -> Record
+}
+```
+
+## Accessing the storage
+
+Cauli manages the storage of `Record`s. Every request and response passing throigh Cauli is recorded with only a few limitations (TODO: List limitations). When displaying your Florets ViewController you have access to the respective Cauli instance and have access to it's `Storage`.


### PR DESCRIPTION
I added a basic jazzy configuration so generating the docs isn't more than just calling `jazzy` in the root of the project.
I also added some additional markdown pages that will be listet in the generated documentation. I am not committed to this way but I thought that be a nice place for additional information, guides and background.