### PR TITLE
Added a RecordSelector to the Configuration

### DIFF
--- a/Cauli.xcodeproj/project.pbxproj
+++ b/Cauli.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1F7BF22C20F77B0A0023D219 /* CauliURLProtocolDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22B20F77B0A0023D219 /* CauliURLProtocolDelegate.swift */; };
 		1F7BF22E20F77B6C0023D219 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22D20F77B6C0023D219 /* Record.swift */; };
 		1F7BF23020F790F50023D219 /* URLSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7BF22F20F790F50023D219 /* URLSessionConfiguration.swift */; };
+		1FB3296F2181CBCD001CA03D /* RecordSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB3296E2181CBCD001CA03D /* RecordSelector.swift */; };
 		1FD0F8812150F0A000BD383B /* Collection+ReduceAsnyc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD0F8802150F0A000BD383B /* Collection+ReduceAsnyc.swift */; };
 		1FE3F72F20F64A2B00233C7C /* Cauli.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE3F72520F64A2B00233C7C /* Cauli.framework */; };
 		1FE3F73620F64A2B00233C7C /* Cauli.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FE3F72820F64A2B00233C7C /* Cauli.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -61,6 +62,7 @@
 		1F7BF22B20F77B0A0023D219 /* CauliURLProtocolDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CauliURLProtocolDelegate.swift; sourceTree = "<group>"; };
 		1F7BF22D20F77B6C0023D219 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		1F7BF22F20F790F50023D219 /* URLSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionConfiguration.swift; sourceTree = "<group>"; };
+		1FB3296E2181CBCD001CA03D /* RecordSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordSelector.swift; sourceTree = "<group>"; };
 		1FD0F8802150F0A000BD383B /* Collection+ReduceAsnyc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+ReduceAsnyc.swift"; sourceTree = "<group>"; };
 		1FE3F72520F64A2B00233C7C /* Cauli.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cauli.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FE3F72820F64A2B00233C7C /* Cauli.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Cauli.h; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 				50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */,
 				1FD0F8802150F0A000BD383B /* Collection+ReduceAsnyc.swift */,
 				1F6BB4552163609100D56F4F /* Configuration.swift */,
+				1FB3296E2181CBCD001CA03D /* RecordSelector.swift */,
 			);
 			path = Cauli;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				1F18B1A4210EF9F500CEDD42 /* Storage.swift in Sources */,
 				1F0EB9E3219DB4C800060F28 /* MockRecordSerializer.swift in Sources */,
 				50A6CFB821178E2200FC57E7 /* URLRequest+Codable.swift in Sources */,
+				1FB3296F2181CBCD001CA03D /* RecordSelector.swift in Sources */,
 				50576BBA210E173C0085DF5E /* Floret.swift in Sources */,
 				1FD0F8812150F0A000BD383B /* Collection+ReduceAsnyc.swift in Sources */,
 				50616E4C214D130C00C8092D /* Result.swift in Sources */,

--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -24,7 +24,7 @@ import Foundation
 
 public class Cauli {
 
-    public static let shared = Cauli([], configuration: Configuration())
+    public static let shared = Cauli([], configuration: Configuration.standard)
 
     public let storage: Storage = MemoryStorage()
     internal let florets: [Floret]
@@ -43,6 +43,10 @@ public class Cauli {
         self.florets = florets
         self.configuration = configuration
         CauliURLProtocol.add(delegate: self)
+        loadConfiguration(configuration)
+    }
+
+    private func loadConfiguration(_ configuration: Configuration) {
     }
 
     public func run() {
@@ -78,6 +82,10 @@ extension Cauli {
 }
 
 extension Cauli: CauliURLProtocolDelegate {
+    func handles(_ record: Record) -> Bool {
+        return configuration.recordSelector.selects(record)
+    }
+
     func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         guard enabled else { completionHandler(record); return }
         enabledFlores.cauli_reduceAsync(record, transform: { record, floret, completion in

--- a/Cauli/CauliURLProtocolDelegate.swift
+++ b/Cauli/CauliURLProtocolDelegate.swift
@@ -23,6 +23,12 @@
 import Foundation
 
 internal protocol CauliURLProtocolDelegate: AnyObject {
+    /// This function will be called to determine if a Record should be handled by this Cauli instance.
+    /// This function is called multiple times for a request and in different states of being processed.
+    ///
+    /// - Parameter record: The Record that should be checked.
+    /// - Returns: Return yes if this Record should be handled.
+    func handles(_ record: Record) -> Bool
     func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void)
     func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void)
 }

--- a/Cauli/Configuration.swift
+++ b/Cauli/Configuration.swift
@@ -23,5 +23,12 @@
 import Foundation
 
 public struct Configuration {
+    public static let standard = Configuration(recordSelector: RecordSelector.max(bytesize: 10 * 1024 * 1024))
 
+    /// Defines if a Record should be handled. This can be used to only select Records by a specific domain, a filetype, a maximum filesize or such.
+    public let recordSelector: RecordSelector
+
+    public init(recordSelector: RecordSelector) {
+        self.recordSelector = recordSelector
+    }
 }

--- a/Cauli/RecordSelector.swift
+++ b/Cauli/RecordSelector.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) 2018 cauli.works
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// A RecordSelector defines a selection of a Record object. It is used in the `Configuration.recordSelector` to
+/// define a subset of Records that should be handled by a Cauli instance.
+public struct RecordSelector {
+    internal let selects: (Record) -> (Bool)
+
+    public init(selects: @escaping (Record) -> (Bool)) {
+        self.selects = selects
+    }
+}
+
+extension RecordSelector {
+    /// Selects every Record.
+    ///
+    /// - Returns: Returns a RecordSelector where every Record is selected.
+    static func all() -> RecordSelector {
+        return RecordSelector { _ in true }
+    }
+
+    /// Selects Records by a maximum filesize
+    ///
+    /// - Parameter bytesize: The maximum size in bytes of the Response body.
+    /// - Returns: Returns a RecordSelector that selects only the Records where the body is smaller or
+    ///     equal than the required size.
+    static func max(bytesize: Int) -> RecordSelector {
+        return RecordSelector { record in
+            switch record.result {
+            case .none: return true
+            case .error: return true
+            case .result(let response):
+                if let data = response.data {
+                    return data.count <= bytesize
+                } else if let urlResponse = response.urlResponse as? HTTPURLResponse,
+                    let contentLength = urlResponse.allHeaderFields["Content-Length"] as? Int {
+                    return contentLength <= bytesize
+                }
+                return false
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements #52.

My main Idea was to be as flexible as possible and being able to filter Records based on any logic.

The CauliURLProtocol now asks all it's delegates if they wan't to handle a certain Record. Depending of the selection the Protocol will reduce it's work as much as possible.

These are a few examples:
* If no delegate handles a Record when checking in the CauliURLProtocol.canInit (for example based on the domain or the requested content-type) a request is not handled by the CauliURLProtocol at all.
* If no delegate handles a Record when receiving data (for example if the max size is exceeded) the data will not be collected and passed along after all the data is received but passed along in the moment it is received.

The default implementation currently uses a filter based on a maximum file size of 10 MB.