### PR TITLE
Added the functionality to en-/disable florets in the UI

### DIFF
--- a/Cauli/CauliViewController.swift
+++ b/Cauli/CauliViewController.swift
@@ -49,8 +49,15 @@ internal class CauliViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let floret = cauli.florets[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-        cell.textLabel?.text = floret.name
+        let enabled = floret.enabled ? "✔️" : "" // ✔️☑️
+        cell.textLabel?.text = floret.name + " " + enabled
         return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        var floret = cauli.florets[indexPath.row]
+        floret.enabled = !floret.enabled
+        tableView.reloadRows(at: [indexPath], with: .automatic)
     }
 
 }


### PR DESCRIPTION
When tapping a floret in the Cauli UI you now can en-/disable them.

<img width="472" alt="bildschirmfoto 2018-11-21 um 09 44 58" src="https://user-images.githubusercontent.com/113456/48829358-58ff9680-ed72-11e8-980b-9e921aa9728c.png">
