### PR TITLE
Removed superfulous throws from the Floret protocol

### DIFF
--- a/Cauli/Floret.swift
+++ b/Cauli/Floret.swift
@@ -56,7 +56,7 @@ public protocol Floret {
     ///   - record: The `Record` that represents the request before it was performed.
     ///   - completionHandler: Call this completion handler exactly once with the
     ///     original or modified `Record`.
-    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void)
+    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void)
 
     /// This function will be called after a request is performed and the response arrived.
     /// The Florets will be called in the order the Cauli instance got initialized with.
@@ -68,7 +68,7 @@ public protocol Floret {
     ///   - record: The `Record` that represents the request after it was performed.
     ///   - completionHandler: Call this completion handler exactly once with the
     ///     original or modified `Record`.
-    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void)
+    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void)
 }
 
 public extension Floret {

--- a/Cauli/Florets/Inspector/InspectorFloret.swift
+++ b/Cauli/Florets/Inspector/InspectorFloret.swift
@@ -27,12 +27,12 @@ public class InspectorFloret: Floret {
 
     public init() {}
 
-    public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
-        try? completionHandler(record)
+    public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
+        completionHandler(record)
     }
 
-    public func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
-        try? completionHandler(record)
+    public func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
+        completionHandler(record)
     }
 
     public func viewController(_ cauli: Cauli) -> UIViewController? {

--- a/Cauli/Florets/Mock/MockFloret.swift
+++ b/Cauli/Florets/Mock/MockFloret.swift
@@ -48,19 +48,19 @@ public class MockFloret: Floret {
         MockFloretStorage.mocker()
     }()
 
-    public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
+    public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         guard mode == .mock,
-            let storage = mockStorage else { try? completionHandler(record); return }
+            let storage = mockStorage else { completionHandler(record); return }
         let storedRecord = storage.mockedRecord(record)
         let record = storedRecord ?? notFoundRecord(for: record)
-        try? completionHandler(record)
+        completionHandler(record)
     }
 
-    public func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
+    public func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         if mode == .record {
             recordStorage.store(record)
         }
-        try? completionHandler(record)
+        completionHandler(record)
     }
 }
 

--- a/Example/cauli-ios-example/cauli-ios-example/Florets/AnonymizeIPFloret.swift
+++ b/Example/cauli-ios-example/cauli-ios-example/Florets/AnonymizeIPFloret.swift
@@ -13,8 +13,8 @@ final class AnonymizeIPFloret: Floret {
     
     var enabled: Bool = true
     
-    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
-        try? completionHandler(record)
+    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
+        completionHandler(record)
     }
     
     
@@ -22,16 +22,16 @@ final class AnonymizeIPFloret: Floret {
     static let ipV4Expression = try! NSRegularExpression(pattern: "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)", options: [])
     static let ipV6Expression = try! NSRegularExpression(pattern: "([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4})", options: [])
 
-    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
+    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         guard case let .result(response) = record.result,
             let data = response.data,
-            let dataString = String(bytes: data, encoding: .utf8) else { try? completionHandler(record); return }
+            let dataString = String(bytes: data, encoding: .utf8) else { completionHandler(record); return }
         let anonymizedString = dataString.replacingOcurrences(of: AnonymizeIPFloret.ipV4Expression, with: "$1.$2.$3.000").replacingOcurrences(of: AnonymizeIPFloret.ipV6Expression, with: "$1:$2:$3:$4:0:0:0:0")
         let anonymizedData = anonymizedString.data(using: .utf8)
         var anonymizedResponse = response
         anonymizedResponse.data = anonymizedData
         var anonymizedRecord = record
         anonymizedRecord.result = .result(anonymizedResponse)
-        try? completionHandler(anonymizedRecord)
+        completionHandler(anonymizedRecord)
     }
 }

--- a/Example/cauli-ios-example/cauli-ios-example/Florets/FindReplaceFloret.swift
+++ b/Example/cauli-ios-example/cauli-ios-example/Florets/FindReplaceFloret.swift
@@ -36,7 +36,7 @@ final class FindReplaceFloret: Floret {
         self.replacements = replacements
     }
     
-    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
+    func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         let record = replacements.reduce(record, { (record, replacement) -> Record in
             var newRecord = record
             let oldValue = record[keyPath: replacement.keyPath]
@@ -44,10 +44,10 @@ final class FindReplaceFloret: Floret {
             newRecord[keyPath: replacement.keyPath] = modifiedValue
             return newRecord
         })
-        try? completionHandler(record)
+        completionHandler(record)
     }
     
-    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) throws -> Void) {
+    func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         let record = replacements.reduce(record, { (record, replacement) -> Record in
             var newRecord = record
             let oldValue = record[keyPath: replacement.keyPath]
@@ -55,6 +55,6 @@ final class FindReplaceFloret: Floret {
             newRecord[keyPath: replacement.keyPath] = modifiedValue
             return newRecord
         })
-        try? completionHandler(record)
+        completionHandler(record)
     }
 }


### PR DESCRIPTION
I am not sure why I added the `throws` here but I think whatever the reason was, it's not necessary anymore.