### PR TITLE
Added missing_docs and fixed most swiftlint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
   - line_length
+  - valid_ibinspectable
 opt_in_rules:
   - empty_count
   - array_init
@@ -15,8 +16,8 @@ opt_in_rules:
   - implicit_return
   - implicitly_unwrapped_optional
   - lower_acl_than_parent
+  - missing_docs
   - modifier_order
-  - multiline_arguments
   - multiline_function_chains
   - multiline_parameters
   - nimble_operator

--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -22,10 +22,17 @@
 
 import Foundation
 
+/// The Cauli class is the starting point of the Cauli framework.
+/// Use the perconfigured `Cauli.shared` or create your own instance.
+/// Please check the Readme.md for more information.
 public class Cauli {
 
+    /// The shared Cauli instance. This instance is fully configured with the default
+    /// Florets. Make sure to call the `run()` function to start the instance.
+    /// You can create a new Cauli instance with your own Configuration and Florets.
     public static let shared = Cauli([], configuration: Configuration.standard)
 
+    /// The Storage used by this instance to store all Records.
     public let storage: Storage = MemoryStorage()
     internal let florets: [Floret]
     private var enabledFlores: [Floret] {
@@ -39,6 +46,11 @@ public class Cauli {
         CauliURLProtocol.remove(delegate: self)
     }
 
+    /// Creates and returns a new Cauli instance.
+    ///
+    /// - Parameters:
+    ///   - florets: The florets that should be used.
+    ///   - configuration: The configuration.
     public init(_ florets: [Floret], configuration: Configuration) {
         Cauli.setup()
         self.florets = florets
@@ -53,16 +65,24 @@ public class Cauli {
         }
     }
 
+    /// The ViewController for the Cauli UI. For the shared Cauli instance,
+    /// and if `enableShakeGesture` in the `Configuration` is set to true
+    /// this ViewController will be shown when shaking the device.
+    /// You can use this function to create a new ViewController and display it manually.
+    ///
+    /// - Returns: A new, unretained ViewController.
     public func viewController() -> UIViewController {
         let cauliViewController = CauliViewController(cauli: self)
         let navigationController = UINavigationController(rootViewController: cauliViewController)
         return navigationController
     }
 
+    /// Starts this Cauli instance.
     public func run() {
         enabled = true
     }
 
+    /// Stops this Cauli instance.
     public func pause() {
         enabled = false
     }

--- a/Cauli/CauliURLProtocol.swift
+++ b/Cauli/CauliURLProtocol.swift
@@ -78,9 +78,9 @@ extension CauliURLProtocol {
         willRequest(record) { record in
             self.record = record
             self.record.requestStarted = Date()
-            if case .result(_) = record.result {
+            if case .result(_)? = record.result {
                 self.urlSession(didCompleteWithError: nil)
-            } else if case let .error(error) = record.result {
+            } else if case let .error(error)? = record.result {
                 self.urlSession(didCompleteWithError: error)
             } else {
                 self.dataTask = self.executingURLSession.dataTask(with: self.record.designatedRequest)
@@ -104,7 +104,7 @@ extension CauliURLProtocol: URLSessionDelegate, URLSessionDataDelegate {
         if CauliURLProtocol.handles(record) {
             try? record.append(receivedData)
         } else {
-            if case let .result(response) = record.result, let data = response.data {
+            if case let .result(response)? = record.result, let data = response.data {
                 self.client?.urlProtocol(self, didLoad: data)
             }
             client?.urlProtocol(self, didLoad: receivedData)
@@ -124,15 +124,15 @@ extension CauliURLProtocol: URLSessionDelegate, URLSessionDataDelegate {
             self.record = record
             self.record.responseRecieved = Date()
             switch record.result {
-            case let .result(response):
+            case let .result(response)?:
                 self.client?.urlProtocol(self, didReceive: response.urlResponse, cacheStoragePolicy: .allowed)
                 if let data = response.data {
                     self.client?.urlProtocol(self, didLoad: data)
                 }
                 self.client?.urlProtocolDidFinishLoading(self)
-            case .error(let error):
+            case .error(let error)?:
                 self.client?.urlProtocol(self, didFailWithError: error)
-            case .none:
+            case nil:
                 self.client?.urlProtocol(self, didFailWithError: NSError(domain: "FIXME", code: 0, userInfo: [:]))
             }
         }

--- a/Cauli/Configuration.swift
+++ b/Cauli/Configuration.swift
@@ -23,6 +23,7 @@
 import Foundation
 
 public struct Configuration {
+    /// The default Configuration.
     public static let standard = Configuration(
         recordSelector: RecordSelector.max(bytesize: 10 * 1024 * 1024),
         enableShakeGesture: true)
@@ -37,6 +38,8 @@ public struct Configuration {
     /// use the `Cauli.viewController()` function to display that ViewController manually.
     public let enableShakeGesture: Bool
 
+    /// Creates a new `Configuration` with the given parameters. Please check the
+    /// properties of a `Configuration` for their meaning.
     public init(recordSelector: RecordSelector, enableShakeGesture: Bool) {
         self.recordSelector = recordSelector
         self.enableShakeGesture = enableShakeGesture

--- a/Cauli/Floret.swift
+++ b/Cauli/Floret.swift
@@ -22,6 +22,9 @@
 
 import Foundation
 
+/// A Floret defines a Cauli plugin. It can be used to intercept and modify
+/// network Requests as well as Responses and to provide a ViewController for
+/// settings or just to display information.
 public protocol Floret {
 
     /// The name of the Floret. This will be used to identify the floret in the UI.
@@ -71,6 +74,7 @@ public protocol Floret {
     func didRespond(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void)
 }
 
+// swiftlint:disable missing_docs
 public extension Floret {
     func viewController(_ cauli: Cauli) -> UIViewController? {
         return nil
@@ -79,3 +83,4 @@ public extension Floret {
         return String(describing: Self.self)
     }
 }
+// swiftlint:enable missing_docs

--- a/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
@@ -57,15 +57,15 @@ internal class InspectorRecordTableViewCell: UITableViewCell {
         methodLabel.text = record.designatedRequest.httpMethod
         pathLabel.text = record.designatedRequest.url?.absoluteString
         switch record.result {
-        case .none:
+        case nil:
             contentTypeLabel.text = ""
             statusCodeLabel.text = "no Response"
             statusCodeLabel.borderColor = .black
-        case .error(let error):
+        case .error(let error)?:
             contentTypeLabel.text = error.localizedDescription
             statusCodeLabel.text = "Error"
             statusCodeLabel.borderColor = InspectorRecordTableViewCell.redColor
-        case .result(let response):
+        case .result(let response)?:
             if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
                 contentTypeLabel.text = httpUrlResponse.allHeaderFields["Content-Type"] as? String
                 statusCodeLabel.text = "\(httpUrlResponse.statusCode)"

--- a/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
@@ -108,13 +108,12 @@ extension RecordTableViewDatasource.Section {
         self.init(title: "Request", items: requestItems)
     }
 
-    init(_ result: Result<Response>) {
+    init(_ result: Result<Response>?) {
         var resultItems: [RecordTableViewDatasource.Item] = []
         switch result {
-        case .none: break
-        case .error(let error):
+        case .error(let error)?:
             resultItems.append(RecordTableViewDatasource.Item(title: "Error", description: error.localizedDescription))
-        case .result(let response):
+        case .result(let response)?:
             resultItems.append(RecordTableViewDatasource.Item(title: "URL", description: response.urlResponse.url?.absoluteString ?? "-"))
             if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
                 resultItems.append(RecordTableViewDatasource.Item(title: "Header Fields", description: httpUrlResponse.allHeaderFields.compactMap { key, value in
@@ -123,6 +122,7 @@ extension RecordTableViewDatasource.Section {
                 resultItems.append(RecordTableViewDatasource.Item(title: "Status Code", description: "\(httpUrlResponse.statusCode)"))
             }
             resultItems.append(RecordTableViewDatasource.Item(title: "Body", description: "\(response.data?.count ?? 0) bytes", value: response.data))
+        case .none: break
         }
         self.init(title: "Response", items: resultItems)
     }

--- a/Cauli/Florets/Mock/MockFloret.swift
+++ b/Cauli/Florets/Mock/MockFloret.swift
@@ -158,10 +158,11 @@ extension MockFloret {
     }
 
     private func notFoundResponse(for request: URLRequest) -> Response {
+        // swiftlint:disable force_unwrapping
         let url = request.url ?? URL(string: "http://example.com")!
-
         let body = "<html><head></head><body><h1>404 - No Mock found</h1></body></html>".data(using: .utf8)!
         let urlResponse = HTTPURLResponse(url: url, statusCode: 404, httpVersion: "1.1", headerFields: nil)!
+        // swiftlint:enable force_unwrapping
         return Response(urlResponse, data: body)
     }
 }

--- a/Cauli/Florets/Mock/MockFloretStorage.swift
+++ b/Cauli/Florets/Mock/MockFloretStorage.swift
@@ -72,7 +72,7 @@ internal class MockFloretStorage {
     }
 
     private static func filename(for record: Record) -> String? {
-        guard case let .result(response) = record.result,
+        guard case let .result(response)? = record.result,
             let httpurlresponse = response.urlResponse as? HTTPURLResponse else {
                 return nil
         }

--- a/Cauli/NSError+Cauli.swift
+++ b/Cauli/NSError+Cauli.swift
@@ -24,9 +24,17 @@ import Foundation
 
 // swiftlint:disable nesting
 extension NSError {
+
+    /// All Cauli related Errors.
     public struct Cauli {
+
+        /// The Cauli NSErrorDomain.
         public let domain = "de.brototyp.cauli"
+
+        /// All Cauli Error Codes.
         public enum Code {}
+
+        /// All keys used in Cauli Errors.
         public enum UserInfoKey {}
     }
 

--- a/Cauli/Record.swift
+++ b/Cauli/Record.swift
@@ -26,7 +26,7 @@ public struct Record: Codable {
     public var identifier: UUID
     public var originalRequest: URLRequest
     public var designatedRequest: URLRequest
-    public var result: Result<Response>
+    public var result: Result<Response>?
     public var requestStarted: Date?
     public var responseRecieved: Date?
 }
@@ -36,13 +36,12 @@ extension Record {
         identifier = UUID()
         originalRequest = request
         designatedRequest = request
-        result = .none
     }
 }
 
 extension Record {
     mutating func append(_ receivedData: Data) throws {
-        guard case let .result(result) = result else {
+        guard case let .result(result)? = result else {
             throw NSError.CauliInternal.appendingDataWithoutResponse(receivedData, record: self)
         }
         var currentData = result.data ?? Data()

--- a/Cauli/RecordSelector.swift
+++ b/Cauli/RecordSelector.swift
@@ -27,6 +27,9 @@ import Foundation
 public struct RecordSelector {
     internal let selects: (Record) -> (Bool)
 
+    /// Creates a new RecordSelector.
+    ///
+    /// - Parameter selects: A closure describing if a Record should be selected or not.
     public init(selects: @escaping (Record) -> (Bool)) {
         self.selects = selects
     }
@@ -48,9 +51,9 @@ extension RecordSelector {
     static func max(bytesize: Int) -> RecordSelector {
         return RecordSelector { record in
             switch record.result {
-            case .none: return true
-            case .error: return true
-            case .result(let response):
+            case nil: return true
+            case .error?: return true
+            case .result(let response)?:
                 if let data = response.data {
                     return data.count <= bytesize
                 } else if let urlResponse = response.urlResponse as? HTTPURLResponse,

--- a/Cauli/Result.swift
+++ b/Cauli/Result.swift
@@ -22,8 +22,11 @@
 
 import Foundation
 
+/// The Result represents a possible result expecting any given type.
+///
+/// - error: An error occured.
+/// - result: The successful result itself
 public enum Result<Type: Codable> {
-    case none
     case error(NSError)
     case result(Type)
 }
@@ -31,7 +34,6 @@ public enum Result<Type: Codable> {
 extension Result: Codable {
 
     private enum CodingKeys: CodingKey {
-        case none
         case error
         case result
     }
@@ -43,17 +45,15 @@ extension Result: Codable {
         } else if let internalError = try? container.decode(InternalError.self) {
             self = .error(NSError(domain: internalError.domain, code: internalError.code, userInfo: internalError.userInfo))
         } else {
-            self = .none
+            let context = DecodingError.Context.init(codingPath: decoder.codingPath, debugDescription: "Could not create Result")
+            throw DecodingError.dataCorrupted(context)
         }
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
-        case .none:
-            try container.encodeNil()
         case .error(let error):
-
             try container.encode(InternalError(domain: error.domain, code: error.code, userInfo: error.compatibleUserInfo))
         case .result(let type):
             try container.encode(type)

--- a/Cauli/Storage.swift
+++ b/Cauli/Storage.swift
@@ -22,6 +22,7 @@
 
 import Foundation
 
+/// A Storage is used to store and retrieve Records. It can be either in memory or on disk.
 public protocol Storage {
 
     /// Adds a record to the storage. Updates a possibly existing record.


### PR DESCRIPTION
I noticed there are some public types and functions we didn't document yet. That is why I added the `missing_docs` rule to swiftlint and fixed most swiftlint warnings.