### PR TITLE
Added InspectorFloret and MockFloret to the Cauli.shared

### DIFF
--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -30,7 +30,7 @@ public class Cauli {
     /// The shared Cauli instance. This instance is fully configured with the default
     /// Florets. Make sure to call the `run()` function to start the instance.
     /// You can create a new Cauli instance with your own Configuration and Florets.
-    public static let shared = Cauli([], configuration: Configuration.standard)
+    public static let shared = Cauli([InspectorFloret(), MockFloret()], configuration: Configuration.standard)
 
     /// The Storage used by this instance to store all Records.
     public let storage: Storage = MemoryStorage()


### PR DESCRIPTION
The documentation stated there are default florets configured but none actually were. I added MockFloret and InspectorFloret.