### PR TITLE
Fixed crash when tapping cells on a record

### DIFF
--- a/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
@@ -72,5 +72,7 @@ extension RecordTableViewController {
         viewContoller.popoverPresentationController?.sourceRect = tableView.cellForRow(at: indexPath)?.bounds ?? .zero
         viewContoller.popoverPresentationController?.permittedArrowDirections = [.up, .down]
         present(viewContoller, animated: true, completion: nil)
+        tableView.deselectRow(at: indexPath, animated: true
+        )
     }
 }


### PR DESCRIPTION
This fixes the crash in #93 and adds the cell deselection in #94 