### PR TITLE
Add a guide listing all core florets.

### DIFF
--- a/docs/guides/Florets.md
+++ b/docs/guides/Florets.md
@@ -1,0 +1,17 @@
+# Florets
+
+## InspectorFloret
+
+The [InspectorFloret](https://cauli.works/docs/Classes/InspectorFloret.html) lets you browse through and share your requests and responses from within the application. Just shake your device (if you are using the default configuration).
+
+## MockFloret
+
+The [MockFloret](https://cauli.works/docs/Classes/MockFloret.html) helps you to easily mock your network requests for tests or to reproduce a bug. You can can use it to record the responses for later mocking and even is compatible to the Format used in the [InspectorFloret](https://cauli.works/docs/Classes/InspectorFloret.html).
+
+## NoCacheFloret
+
+The [NoCacheFloret](https://cauli.works/docs/Classes/NoCacheFloret.html) modifies the designatedRequest and the response of a record to prevent returning cached data or writing data to the cache.
+
+## FindReplaceFloret
+
+The [FindReplaceFloret](https://cauli.works/docs/Classes/FindReplaceFloret.html) can be used to easily replace any part of a request or response by using a [RecordModifier](https://cauli.works/docs/Classes/FindReplaceFloret/RecordModifier.html)


### PR DESCRIPTION
This PR adds a guide listing all core florets with a short introduction. I thought this might be a little nicer then listing them directly in the readme. Maybe just linking this guide right from the readme?