### PR TITLE
URI Label in InspectorFloret is too short

### DIFF
--- a/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.xib
+++ b/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.xib
@@ -20,7 +20,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="GET" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gpj-7q-WGE" customClass="TagLabel" customModule="Cauli" customModuleProvider="target">
-                        <rect key="frame" x="11" y="9" width="55" height="27.5"/>
+                        <rect key="frame" x="11" y="9" width="55" height="27"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -43,7 +43,7 @@
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="/organizations/cauliframework" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Daq-5Q-ci8">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="/organizations/cauliframework" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Daq-5Q-ci8">
                         <rect key="frame" x="80" y="9" width="245" height="27.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <nil key="textColor"/>
@@ -55,7 +55,6 @@
                     <constraint firstItem="iLL-7a-gbP" firstAttribute="trailing" secondItem="gpj-7q-WGE" secondAttribute="trailing" id="3Ak-1y-NrP"/>
                     <constraint firstAttribute="trailing" secondItem="Daq-5Q-ci8" secondAttribute="trailing" constant="11" id="3DA-dN-OJ7"/>
                     <constraint firstItem="iLL-7a-gbP" firstAttribute="top" secondItem="8QC-S5-nAc" secondAttribute="top" id="6Ly-0F-drW"/>
-                    <constraint firstItem="Daq-5Q-ci8" firstAttribute="firstBaseline" secondItem="gpj-7q-WGE" secondAttribute="firstBaseline" id="CVk-B0-O4b"/>
                     <constraint firstItem="Dwe-2a-sT2" firstAttribute="leading" secondItem="8QC-S5-nAc" secondAttribute="trailing" constant="9" id="KxH-bT-2il"/>
                     <constraint firstItem="8QC-S5-nAc" firstAttribute="bottom" secondItem="Dwe-2a-sT2" secondAttribute="bottom" id="LOF-IK-d7A"/>
                     <constraint firstAttribute="trailing" secondItem="Dwe-2a-sT2" secondAttribute="trailing" constant="11" id="M8v-cB-N4e"/>
@@ -65,7 +64,6 @@
                     <constraint firstAttribute="bottom" secondItem="Dwe-2a-sT2" secondAttribute="bottom" constant="9" id="YuN-eG-s4v"/>
                     <constraint firstItem="gpj-7q-WGE" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="9" id="bpH-2b-oQz"/>
                     <constraint firstItem="Daq-5Q-ci8" firstAttribute="top" secondItem="gpj-7q-WGE" secondAttribute="top" id="fGl-a9-RqJ"/>
-                    <constraint firstItem="Daq-5Q-ci8" firstAttribute="bottom" secondItem="gpj-7q-WGE" secondAttribute="bottom" id="iXh-0M-yVG"/>
                     <constraint firstItem="Dwe-2a-sT2" firstAttribute="top" secondItem="Daq-5Q-ci8" secondAttribute="bottom" constant="9" id="lCH-io-4h4"/>
                     <constraint firstItem="Daq-5Q-ci8" firstAttribute="leading" secondItem="gpj-7q-WGE" secondAttribute="trailing" constant="14" id="oth-P3-cmR"/>
                     <constraint firstItem="8QC-S5-nAc" firstAttribute="top" secondItem="Dwe-2a-sT2" secondAttribute="top" id="qDp-tz-eAH"/>


### PR DESCRIPTION
I am using Cauli to get insight into requests made to an API in my app. All API calls go the the same domain and first path, the interesting part that differs with each request happens in the rear part of the URL.

The current InspectorFloret request list only displays information in this case that is the same for every request, which makes finding the request you are looking for unnecessarily hard.

This small PR makes the URL label multiline while keeping the height of all other labels. This way you can always see the full URL. 