### PR TITLE
Changed the `max` and `all` functions on `RecordSelector` to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## Unreleased
+* **improvement** Changed the `max` and `all` functions on `RecordSelector` to be public. [#136](https://github.com/cauliframework/cauli/issues/136)
+
 ## 0.9
 * First public release

--- a/Cauli/Configuration/RecordSelector.swift
+++ b/Cauli/Configuration/RecordSelector.swift
@@ -35,7 +35,7 @@ public struct RecordSelector {
     }
 }
 
-extension RecordSelector {
+public extension RecordSelector {
     /// Selects every Record.
     ///
     /// - Returns: Returns a RecordSelector where every Record is selected.


### PR DESCRIPTION
This fixes #136 