### PR TITLE
#168 replaced legacy bundle identifier references #trivial

### DIFF
--- a/Cauli/Extensions/NSError+Cauli.swift
+++ b/Cauli/Extensions/NSError+Cauli.swift
@@ -29,7 +29,7 @@ extension NSError {
     public struct Cauli {
 
         /// The Cauli NSErrorDomain.
-        public let domain = "de.brototyp.cauli"
+        public let domain = "works.cauli.framework"
 
         /// All Cauli Error Codes.
         public enum Code {}
@@ -39,7 +39,7 @@ extension NSError {
     }
 
     internal struct CauliInternal {
-        internal static let domain = "de.brototyp.cauli.internal"
+        internal static let domain = "works.cauli.framework.internal"
         internal enum Code: Int {
             case failedToAppendData
             case appendingDataWithoutResponse

--- a/Example/cauli-ios-example/cauli-ios-example.xcodeproj/project.pbxproj
+++ b/Example/cauli-ios-example/cauli-ios-example.xcodeproj/project.pbxproj
@@ -402,7 +402,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "de.brototyp.cauli-ios-example";
+				PRODUCT_BUNDLE_IDENTIFIER = "works.cauli.framework.ios-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -422,7 +422,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "de.brototyp.cauli-ios-example";
+				PRODUCT_BUNDLE_IDENTIFIER = "works.cauli.framework.ios-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
with cauli specific domain

closes #168 