### PR TITLE
#182 storage protocol

### DIFF
--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -55,7 +55,10 @@ public class Cauli {
         Cauli.setup()
         self.florets = florets
         self.configuration = configuration
-        self.storage = MemoryStorage(capacity: configuration.storageCapacity, preStorageRecordModifier: configuration.preStorageRecordModifier)
+        // TODO: Fixme
+        let storage: Storage? = nil
+        self.storage = storage!
+//        self.storage = MemoryStorage(capacity: configuration.storageCapacity, preStorageRecordModifier: configuration.preStorageRecordModifier)
         CauliURLProtocol.add(delegate: self)
         loadConfiguration(configuration)
     }

--- a/Cauli/CauliURLProtocol/CauliURLProtocol.swift
+++ b/Cauli/CauliURLProtocol/CauliURLProtocol.swift
@@ -72,20 +72,21 @@ extension CauliURLProtocol {
         return request
     }
 
-    override func startLoading() {
-        willRequest(record) { record in
-            self.record = record
-            self.record.requestStarted = Date()
-            if case .result(_)? = record.result {
-                self.urlSession(didCompleteWithError: nil)
-            } else if case let .error(error)? = record.result {
-                self.urlSession(didCompleteWithError: error)
-            } else {
-                self.dataTask = self.executingURLSession.dataTask(with: self.record.designatedRequest)
-                self.dataTask?.resume()
-            }
-        }
-    }
+    // TODO: Fixme
+//    override func startLoading() {
+//        willRequest(record) { record in
+//            self.record = record
+//            self.record.requestStarted = Date()
+//            if case .result(_)? = record.result {
+//                self.urlSession(didCompleteWithError: nil)
+//            } else if case let .error(error)? = record.result {
+//                self.urlSession(didCompleteWithError: error)
+//            } else {
+//                self.dataTask = self.executingURLSession.dataTask(with: self.record.designatedRequest)
+//                self.dataTask?.resume()
+//            }
+//        }
+//    }
 
     override func stopLoading() {
         dataTask?.cancel()
@@ -93,62 +94,63 @@ extension CauliURLProtocol {
     }
 }
 
+// TODO: Fixme
 extension CauliURLProtocol: URLSessionDelegate, URLSessionDataDelegate {
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        record.result = .result(Response(response, data: nil))
-        completionHandler(.allow)
-    }
-
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive receivedData: Data) {
-        if CauliURLProtocol.handles(record) {
-            try? record.append(receivedData: receivedData)
-        } else {
-            if case let .result(response)? = record.result, let data = response.data {
-                self.client?.urlProtocol(self, didLoad: data)
-            }
-            client?.urlProtocol(self, didLoad: receivedData)
-        }
-    }
-
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        urlSession(didCompleteWithError: error)
-    }
-
-    private func urlSession(didCompleteWithError error: Error?) {
-        invalidateURLSession()
-        if let error = error {
-            record.result = .error(error as NSError)
-        }
-
-        didRespond(record) { record in
-            self.record = record
-            self.record.responseReceived = Date()
-            switch record.result {
-            case let .result(response)?:
-                self.client?.urlProtocol(self, didReceive: response.urlResponse, cacheStoragePolicy: .allowed)
-                if let data = response.data {
-                    self.client?.urlProtocol(self, didLoad: data)
-                }
-                self.client?.urlProtocolDidFinishLoading(self)
-            case .error(let error)?:
-                self.client?.urlProtocol(self, didFailWithError: error)
-            case nil:
-                self.client?.urlProtocol(self, didFailWithError: NSError(domain: "FIXME", code: 0, userInfo: [:]))
-            }
-        }
-    }
-
-    @available(iOS 10.0, *)
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        // possibly add the metrics to the record in the future
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        let authenticationChallengeProxy = CauliAuthenticationChallengeProxy(authChallengeCompletionHandler: completionHandler)
-        let proxiedChallenge = URLAuthenticationChallenge(authenticationChallenge: challenge, sender: authenticationChallengeProxy)
-        self.authenticationChallengeProxy = authenticationChallengeProxy
-        client?.urlProtocol(self, didReceive: proxiedChallenge)
-    }
+//    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+//        record.result = .result(Response(response, data: nil))
+//        completionHandler(.allow)
+//    }
+//
+//    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive receivedData: Data) {
+//        if CauliURLProtocol.handles(record) {
+//            try? record.append(receivedData: receivedData)
+//        } else {
+//            if case let .result(response)? = record.result, let data = response.data {
+//                self.client?.urlProtocol(self, didLoad: data)
+//            }
+//            client?.urlProtocol(self, didLoad: receivedData)
+//        }
+//    }
+//
+//    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+//        urlSession(didCompleteWithError: error)
+//    }
+//
+//    private func urlSession(didCompleteWithError error: Error?) {
+//        invalidateURLSession()
+//        if let error = error {
+//            record.result = .error(error as NSError)
+//        }
+//
+//        didRespond(record) { record in
+//            self.record = record
+//            self.record.responseReceived = Date()
+//            switch record.result {
+//            case let .result(response)?:
+//                self.client?.urlProtocol(self, didReceive: response.urlResponse, cacheStoragePolicy: .allowed)
+//                if let data = response.data {
+//                    self.client?.urlProtocol(self, didLoad: data)
+//                }
+//                self.client?.urlProtocolDidFinishLoading(self)
+//            case .error(let error)?:
+//                self.client?.urlProtocol(self, didFailWithError: error)
+//            case nil:
+//                self.client?.urlProtocol(self, didFailWithError: NSError(domain: "FIXME", code: 0, userInfo: [:]))
+//            }
+//        }
+//    }
+//
+//    @available(iOS 10.0, *)
+//    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+//        // possibly add the metrics to the record in the future
+//    }
+//
+//    func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+//        let authenticationChallengeProxy = CauliAuthenticationChallengeProxy(authChallengeCompletionHandler: completionHandler)
+//        let proxiedChallenge = URLAuthenticationChallenge(authenticationChallenge: challenge, sender: authenticationChallengeProxy)
+//        self.authenticationChallengeProxy = authenticationChallengeProxy
+//        client?.urlProtocol(self, didReceive: proxiedChallenge)
+//    }
 }
 
 extension CauliURLProtocol {

--- a/Cauli/Configuration/RecordSelector.swift
+++ b/Cauli/Configuration/RecordSelector.swift
@@ -51,20 +51,9 @@ public extension RecordSelector {
     ///     equal than the required size.
     static func max(bytesize: Int) -> RecordSelector {
         return RecordSelector { record in
-            guard record.designatedRequest.httpBody?.count ?? 0 <= bytesize else { return false }
-            switch record.result {
-            case nil: return true
-            case .error?: return true
-            case .result(let response)?:
-                if let data = response.data {
-                    return data.count <= bytesize
-                } else if let urlResponse = response.urlResponse as? HTTPURLResponse,
-                    let contentLengthString = urlResponse.allHeaderFields["Content-Length"] as? String,
-                    let contentLength = Int(contentLengthString) {
-                    return contentLength <= bytesize
-                }
-                return true
-            }
+            let requestBodySize = record.requestBodySize ?? 0
+            let responseBodySize = record.responseBodySize ?? 0
+            return requestBodySize + responseBodySize <= bytesize
         }
     }
 }

--- a/Cauli/Data structures/Record.swift
+++ b/Cauli/Data structures/Record.swift
@@ -28,18 +28,12 @@ public struct Record {
     /// two Records are assumed to be the same.
     public var identifier: UUID
 
-    /// The originalRequest is the request passed on to the URL loading system.
-    /// The originalRequest should not be changed by any floret.
-    public var originalRequest: URLRequest
-
-    /// The designatedRequest will initially be the same as the originalRequest
-    /// but can be changed by every Floret. The designatedRequest is the one
-    /// that will be executed in the end.
-    public var designatedRequest: URLRequest
+    /// The request executed. Once the record is received from the storage, the
+    /// httpBody will be converted to a httpBodyStream.
+    public var request: URLRequest
 
     /// The result will be nil until either the URL loading system failed to perform the
-    /// request, or the response is received. The `data` of the `Response` can be incomplete
-    /// while receiving.
+    /// request, or the response is received. The `responseBodyStream` will be set by the 
     public var result: Result<Response>?
 
     /// The requestStarted Date is set after all florets finished their `willRequest` function.
@@ -47,6 +41,12 @@ public struct Record {
 
     /// The responseReceived Date is set after all florets finished their `didRespond` function.
     public var responseReceived: Date?
+
+    /// The size of the request body data. Nil if the request body was empty.
+    public var requestBodySize: Int64?
+
+    /// The size of the response body data. Nil if the response body was empty.
+    public var responseBodySize: Int64?
 }
 
 extension Record: Codable {}
@@ -54,24 +54,23 @@ extension Record: Codable {}
 extension Record {
     init(_ request: URLRequest) {
         identifier = UUID()
-        originalRequest = request
-        designatedRequest = request
+        self.request = request
     }
 }
 
 extension Record {
-    internal mutating func append(receivedData: Data) throws {
-        guard case let .result(result)? = result else {
-            throw NSError.CauliInternal.appendingDataWithoutResponse(receivedData, record: self)
-        }
-        var currentData = result.data ?? Data()
-        currentData.append(receivedData)
-        self.result = .result(Response(result.urlResponse, data: currentData))
-    }
+//    internal mutating func append(receivedData: Data) throws {
+//        guard case let .result(result)? = result else {
+//            throw NSError.CauliInternal.appendingDataWithoutResponse(receivedData, record: self)
+//        }
+//        var currentData = result.data ?? Data()
+//        currentData.append(receivedData)
+//        self.result = .result(Response(result.urlResponse, data: currentData))
+//    }
 }
 
 extension Record {
-    internal func swapped(to path: URL) -> SwappedRecord {
-        return SwappedRecord(self, folder: path)
-    }
+//    internal func swapped(to path: URL) -> SwappedRecord {
+//        return SwappedRecord(self, folder: path)
+//    }
 }

--- a/Cauli/Data structures/Response.swift
+++ b/Cauli/Data structures/Response.swift
@@ -23,9 +23,9 @@
 import Foundation
 
 /// The `Response` wrapps the `URLResponse` and the data received from the server.
-public struct Response: Codable {
+public struct Response {
     /// The `Data` received for a request.
-    public var data: Data?
+    public var responseBodyStream: InputStream?
 
     /// The `URLResponse` for a request.
     public var urlResponse: URLResponse {
@@ -41,11 +41,30 @@ public struct Response: Codable {
     ///
     /// - Parameters:
     ///   - urlResponse: The URLResponse
-    ///   - data: Optional received data
-    init(_ urlResponse: URLResponse, data: Data?) {
-        self.data = data
+    ///   - responseBodyStream: The data received for a request.
+    init(_ urlResponse: URLResponse, responseBodyStream: InputStream?) {
+        self.responseBodyStream = responseBodyStream
         urlResponseRepresentable = URLResponseRepresentable(urlResponse)
     }
 
     private var urlResponseRepresentable: URLResponseRepresentable
+}
+
+extension Response: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case response
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let response = try container.decode(URLResponseRepresentable.self)
+        self.urlResponseRepresentable = response
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(urlResponseRepresentable)
+    }
+
 }

--- a/Cauli/Florets/HTTPBodyStreamFloret/HTTPBodyStreamFloret.swift
+++ b/Cauli/Florets/HTTPBodyStreamFloret/HTTPBodyStreamFloret.swift
@@ -43,13 +43,13 @@ public class HTTPBodyStreamFloret: InterceptingFloret {
     }
 
     public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
-        guard let httpBodyStream = record.designatedRequest.httpBodyStream,
+        guard let httpBodyStream = record.request.httpBodyStream,
             let data = data(reading: httpBodyStream) else {
             return completionHandler(record)
         }
         var record = record
-        record.designatedRequest.httpBodyStream = nil
-        record.designatedRequest.httpBody = data
+        record.request.httpBodyStream = nil
+        record.request.httpBody = data
         completionHandler(record)
     }
 

--- a/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
@@ -45,8 +45,8 @@ internal class InspectorRecordTableViewCell: UITableViewCell {
         } else {
             timeLabel.text = ""
         }
-        methodLabel.text = record.designatedRequest.httpMethod
-        let pathString = record.designatedRequest.url?.absoluteString ?? ""
+        methodLabel.text = record.request.httpMethod
+        let pathString = record.request.url?.absoluteString ?? ""
         let pathAttributedString = NSMutableAttributedString(string: pathString)
         if let stringToHighlight = stringToHighlight {
             var rangeToSearch = pathString.startIndex..<pathString.endIndex

--- a/Cauli/Florets/Inspector/Record List/InspectorTableViewController.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorTableViewController.swift
@@ -65,10 +65,11 @@ internal class InspectorTableViewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if dataSource.items.isEmpty {
-            let records = cauli.storage.records(InspectorTableViewController.recordPageSize, after: dataSource.items.last)
-            dataSource.append(records: records, to: tableView)
-        }
+        // TODO: fixme
+//        if dataSource.items.isEmpty {
+//            let records = cauli.storage.records(InspectorTableViewController.recordPageSize, after: dataSource.items.last)
+//            dataSource.append(records: records, to: tableView)
+//        }
         searchController.searchBar.isHidden = false
     }
 
@@ -90,19 +91,20 @@ internal class InspectorTableViewController: UITableViewController {
     }
 
     fileprivate func loadAdditionalRecordsIfNeeded() {
-        let distanceToBottom = tableView.contentSize.height - tableView.frame.height - tableView.contentOffset.y
-        guard !scrolledToEnd, !isLoading, distanceToBottom < 100 else { return }
-        isLoading = true
-        let newRecords = cauli.storage.records(InspectorTableViewController.recordPageSize, after: dataSource.items.last)
-        guard !newRecords.isEmpty  else {
-            isLoading = false
-            scrolledToEnd = true
-            return
-        }
-
-        dataSource.append(records: newRecords, to: tableView) { [weak self] _ in
-            self?.isLoading = false
-        }
+        // TODO: Fixme
+//        let distanceToBottom = tableView.contentSize.height - tableView.frame.height - tableView.contentOffset.y
+//        guard !scrolledToEnd, !isLoading, distanceToBottom < 100 else { return }
+//        isLoading = true
+//        let newRecords = cauli.storage.records(InspectorTableViewController.recordPageSize, after: dataSource.items.last)
+//        guard !newRecords.isEmpty  else {
+//            isLoading = false
+//            scrolledToEnd = true
+//            return
+//        }
+//
+//        dataSource.append(records: newRecords, to: tableView) { [weak self] _ in
+//            self?.isLoading = false
+//        }
     }
 }
 

--- a/Cauli/Florets/Inspector/Record List/InspectorTableViewDatasource.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorTableViewDatasource.swift
@@ -52,7 +52,7 @@ internal class InspectorTableViewDatasource: NSObject {
             return
         }
         filter = RecordSelector { record in
-            guard let urlString = record.designatedRequest.url?.absoluteString else {
+            guard let urlString = record.request.url?.absoluteString else {
                 return false
             }
             return urlString.range(of: filterString, options: String.CompareOptions.caseInsensitive) != nil

--- a/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
@@ -50,12 +50,13 @@ internal class RecordTableViewController: UITableViewController {
     }
 
     @objc func shareButtonTapped() {
-        guard let tempPath = MockRecordSerializer.write(record: record) else { return }
-
-        let allRecordFiles = (try? FileManager.default.contentsOfDirectory(at: tempPath, includingPropertiesForKeys: nil, options: [])) ?? []
-
-        let viewContoller = UIActivityViewController(activityItems: allRecordFiles, applicationActivities: nil)
-        present(viewContoller, animated: true, completion: nil)
+        // TODO: Fixme
+//        guard let tempPath = MockRecordSerializer.write(record: record) else { return }
+//
+//        let allRecordFiles = (try? FileManager.default.contentsOfDirectory(at: tempPath, includingPropertiesForKeys: nil, options: [])) ?? []
+//
+//        let viewContoller = UIActivityViewController(activityItems: allRecordFiles, applicationActivities: nil)
+//        present(viewContoller, animated: true, completion: nil)
     }
 
 }

--- a/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
@@ -32,7 +32,7 @@ internal class RecordTableViewDatasource: NSObject {
     }
 
     convenience init(_ record: Record) {
-        let requestSection = Section(record.designatedRequest)
+        let requestSection = Section(record.request)
         let responseSection = Section(record.result)
         self.init([requestSection, responseSection])
     }
@@ -100,22 +100,23 @@ extension RecordTableViewDatasource.Item {
         self.description = description
         self.value = value
     }
-    static func forBody(in response: Response) -> RecordTableViewDatasource.Item {
-        // swiftlint:disable trailing_closure
-        return RecordTableViewDatasource.Item(title: "Body", description: "\(response.data?.count ?? 0) bytes", value: {
-            guard let data = response.data else { return nil }
-            let fileName = response.urlResponse.suggestedFilename ?? UUID().uuidString
-            let tmpFolder = URL(fileURLWithPath: NSTemporaryDirectory())
-            let filePath = tmpFolder.appendingPathComponent(fileName)
-            do {
-                try data.write(to: filePath)
-                return filePath
-            } catch {
-                return nil
-            }
-        })
-        // swiftlint:enable trailing_closure
-    }
+    // TODO: fixme
+//    static func forBody(in response: Response) -> RecordTableViewDatasource.Item {
+//        // swiftlint:disable trailing_closure
+//        return RecordTableViewDatasource.Item(title: "Body", description: "\(response.data?.count ?? 0) bytes", value: {
+//            guard let data = response.data else { return nil }
+//            let fileName = response.urlResponse.suggestedFilename ?? UUID().uuidString
+//            let tmpFolder = URL(fileURLWithPath: NSTemporaryDirectory())
+//            let filePath = tmpFolder.appendingPathComponent(fileName)
+//            do {
+//                try data.write(to: filePath)
+//                return filePath
+//            } catch {
+//                return nil
+//            }
+//        })
+//        // swiftlint:enable trailing_closure
+//    }
 }
 
 extension RecordTableViewDatasource.Section {
@@ -135,21 +136,22 @@ extension RecordTableViewDatasource.Section {
 
     init(_ result: Result<Response>?) {
         var resultItems: [RecordTableViewDatasource.Item] = []
-        switch result {
-        case .error(let error)?:
-            resultItems.append(RecordTableViewDatasource.Item(title: "Error", description: error.localizedDescription))
-        case .result(let response)?:
-            resultItems.append(RecordTableViewDatasource.Item(title: "URL", description: response.urlResponse.url?.absoluteString ?? "-", value: response.urlResponse.url))
-            if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
-                resultItems.append(RecordTableViewDatasource.Item(title: "Header Fields", description: httpUrlResponse.allHeaderFields.compactMap { key, value in
-                    "\(key): \(value)"
-                }
-                    .joined(separator: "\n"), value: httpUrlResponse.allHeaderFields))
-                resultItems.append(RecordTableViewDatasource.Item(title: "Status Code", description: "\(httpUrlResponse.statusCode)"))
-            }
-            resultItems.append(RecordTableViewDatasource.Item.forBody(in: response))
-        case .none: break
-        }
+        // TODO: Fixme
+//        switch result {
+//        case .error(let error)?:
+//            resultItems.append(RecordTableViewDatasource.Item(title: "Error", description: error.localizedDescription))
+//        case .result(let response)?:
+//            resultItems.append(RecordTableViewDatasource.Item(title: "URL", description: response.urlResponse.url?.absoluteString ?? "-", value: response.urlResponse.url))
+//            if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
+//                resultItems.append(RecordTableViewDatasource.Item(title: "Header Fields", description: httpUrlResponse.allHeaderFields.compactMap { key, value in
+//                    "\(key): \(value)"
+//                }
+//                    .joined(separator: "\n"), value: httpUrlResponse.allHeaderFields))
+//                resultItems.append(RecordTableViewDatasource.Item(title: "Status Code", description: "\(httpUrlResponse.statusCode)"))
+//            }
+//            resultItems.append(RecordTableViewDatasource.Item.forBody(in: response))
+//        case .none: break
+//        }
         self.init(title: "Response", items: resultItems)
     }
 

--- a/Cauli/Florets/Mock/MockFloret.swift
+++ b/Cauli/Florets/Mock/MockFloret.swift
@@ -89,9 +89,10 @@ public class MockFloret: InterceptingFloret {
 
     public func willRequest(_ record: Record, modificationCompletionHandler completionHandler: @escaping (Record) -> Void) {
         guard case .mock(let forced) = mode else { completionHandler(record); return }
-        var result = resultForRequest(record.designatedRequest)
+        var result = resultForRequest(record.request)
         if forced && result == nil {
-             result = Result<Response>.notFound(for: record.designatedRequest)
+            // TODO: Fixme
+//             result = Result<Response>.notFound(for: record.designatedRequest)
         }
         if let result = result {
             var record = record
@@ -214,24 +215,24 @@ extension MockFloret {
     }
 }
 
-extension Result {
-    /// Creates an returns a not-found (404) result for the given request.
-    ///
-    /// - Parameter request: The request.
-    /// - Returns: The not-found `Result` for the given request.
-    public static func notFound(for request: URLRequest) -> Result<Response> {
-        let response = Response.notFound(for: request)
-        return .result(response)
-    }
-}
+//extension Result {
+//    /// Creates an returns a not-found (404) result for the given request.
+//    ///
+//    /// - Parameter request: The request.
+//    /// - Returns: The not-found `Result` for the given request.
+//    public static func notFound(for request: URLRequest) -> Result<Response> {
+//        let response = Response.notFound(for: request)
+//        return .result(response)
+//    }
+//}
 
-internal extension Response {
-    static func notFound(for request: URLRequest) -> Response {
-        // swiftlint:disable force_unwrapping
-        let url = request.url ?? URL(string: "http://example.com")!
-        let body = "<html><head></head><body><h1>404 - No Mock found</h1></body></html>".data(using: .utf8)!
-        let urlResponse = HTTPURLResponse(url: url, statusCode: 404, httpVersion: "1.1", headerFields: nil)!
-        // swiftlint:enable force_unwrapping
-        return Response(urlResponse, data: body)
-    }
-}
+//internal extension Response {
+//    static func notFound(for request: URLRequest) -> Response {
+//        // swiftlint:disable force_unwrapping
+//        let url = request.url ?? URL(string: "http://example.com")!
+//        let body = "<html><head></head><body><h1>404 - No Mock found</h1></body></html>".data(using: .utf8)!
+//        let urlResponse = HTTPURLResponse(url: url, statusCode: 404, httpVersion: "1.1", headerFields: nil)!
+//        // swiftlint:enable force_unwrapping
+//        return Response(urlResponse, data: body)
+//    }
+//}

--- a/Cauli/Florets/Mock/MockFloretStorage.swift
+++ b/Cauli/Florets/Mock/MockFloretStorage.swift
@@ -35,34 +35,38 @@ internal class MockFloretStorage {
     func store(_ record: Record) {
         guard case .result(let response)? = record.result,
             let responseFoldername = MockFloretStorage.foldername(for: response) else { return }
-        let requestFoldername = MockFloretStorage.foldername(for: record.designatedRequest)
+        let requestFoldername = MockFloretStorage.foldername(for: record.request)
         let requestPath = path.appendingPathComponent(requestFoldername, isDirectory: true)
         let storedResponseUrls = (try? FileManager.default.contentsOfDirectory(atPath: requestPath.path)) ?? []
         if storedResponseUrls.contains(where: { $0.starts(with: responseFoldername) }) {
             // already recorded
             return
         }
-        if let tempRecordPath = MockRecordSerializer.write(record: record) {
-            let responsePath = requestPath.appendingPathComponent(responseFoldername, isDirectory: true)
-            try? FileManager.default.createDirectory(at: requestPath, withIntermediateDirectories: true, attributes: nil)
-            try? FileManager.default.moveItem(at: tempRecordPath, to: responsePath)
-        }
+        // TODO: Fixme
+//        if let tempRecordPath = MockRecordSerializer.write(record: record) {
+//            let responsePath = requestPath.appendingPathComponent(responseFoldername, isDirectory: true)
+//            try? FileManager.default.createDirectory(at: requestPath, withIntermediateDirectories: true, attributes: nil)
+//            try? FileManager.default.moveItem(at: tempRecordPath, to: responsePath)
+//        }
     }
 
     func results(for request: URLRequest) -> [Result<Response>] {
         let requestFoldername = MockFloretStorage.foldername(for: request)
         let requestPath = path.appendingPathComponent(requestFoldername, isDirectory: true)
         let storedResponseUrls = try? FileManager.default.contentsOfDirectory(at: requestPath, includingPropertiesForKeys: [], options: [])
-        return storedResponseUrls?.lazy.compactMap { url in
-            MockRecordSerializer.record(from: url)?.result
+        return storedResponseUrls?.lazy.compactMap { _ in
+            // TODO: Fixme
+            return nil
+//            MockRecordSerializer.record(from: url)?.result
         } ?? []
     }
 
     func resultForPath(_ path: String) -> Result<Response>? {
         let absolutePath = self.path.appendingPathComponent(path, isDirectory: true)
-        if let record = MockRecordSerializer.record(from: absolutePath) {
-            return record.result
-        }
+        // TODO: Fixme
+//        if let record = MockRecordSerializer.record(from: absolutePath) {
+//            return record.result
+//        }
         return nil
     }
 
@@ -74,12 +78,14 @@ internal class MockFloretStorage {
             return MD5Digest(from: Data(etag.utf8)).description
         } else {
             let codeHash = MD5Digest(from: Data("\(httpurlresponse.statusCode)".utf8)).description
-            if let data = response.data {
-                let dataHash = MD5Digest(from: data).description
-                return MD5Digest(from: Data("\(codeHash)\(dataHash)".utf8)).description
-            } else {
-                return codeHash
-            }
+            // TODO: Fixme
+//            if let data = response.data {
+//                let dataHash = MD5Digest(from: data).description
+//                return MD5Digest(from: Data("\(codeHash)\(dataHash)".utf8)).description
+//            } else {
+//                return codeHash
+//            }
+            return nil
         }
     }
 

--- a/Cauli/Florets/Mock/MockRecordSerializer.swift
+++ b/Cauli/Florets/Mock/MockRecordSerializer.swift
@@ -22,50 +22,50 @@
 
 import Foundation
 
-internal class MockRecordSerializer {
-
-    /// Returns a path to a temporary folder where a record is written to.
-    ///
-    /// - Parameter record: The record to write on disk.
-    /// - Returns: The path to the temporary folder.
-    static func write(record: Record) -> URL? {
-        let tempPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
-
-        do {
-            try FileManager.default.createDirectory(at: tempPath, withIntermediateDirectories: true, attributes: nil)
-            let swappedRecord = record.swapped(to: tempPath)
-            guard let data = self.data(for: swappedRecord) else { return nil }
-            let filepath = tempPath.appendingPathComponent("record.json")
-            try data.write(to: filepath)
-        } catch {
-            try? FileManager.default.removeItem(at: tempPath)
-            return nil
-        }
-
-        return tempPath
-    }
-
-    static func record(from folder: URL) -> Record? {
-        let filepath = folder.appendingPathComponent("record.json")
-        if let data = try? Data(contentsOf: filepath),
-            let swappedRecord = MockRecordSerializer.record(with: data) {
-            return swappedRecord.record(in: folder)
-        } else {
-            return nil
-        }
-    }
-
-    private static func data(for record: SwappedRecord) -> Data? {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        guard let data = try? encoder.encode(record) else { return nil }
-        return data
-    }
-
-    private static func record(with data: Data) -> SwappedRecord? {
-        let decoder = JSONDecoder()
-        guard let record = try? decoder.decode(SwappedRecord.self, from: data) else { return nil }
-        return record
-    }
-
-}
+//internal class MockRecordSerializer {
+//
+//    /// Returns a path to a temporary folder where a record is written to.
+//    ///
+//    /// - Parameter record: The record to write on disk.
+//    /// - Returns: The path to the temporary folder.
+//    static func write(record: Record) -> URL? {
+//        let tempPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
+//
+//        do {
+//            try FileManager.default.createDirectory(at: tempPath, withIntermediateDirectories: true, attributes: nil)
+//            let swappedRecord = record.swapped(to: tempPath)
+//            guard let data = self.data(for: swappedRecord) else { return nil }
+//            let filepath = tempPath.appendingPathComponent("record.json")
+//            try data.write(to: filepath)
+//        } catch {
+//            try? FileManager.default.removeItem(at: tempPath)
+//            return nil
+//        }
+//
+//        return tempPath
+//    }
+//
+//    static func record(from folder: URL) -> Record? {
+//        let filepath = folder.appendingPathComponent("record.json")
+//        if let data = try? Data(contentsOf: filepath),
+//            let swappedRecord = MockRecordSerializer.record(with: data) {
+//            return swappedRecord.record(in: folder)
+//        } else {
+//            return nil
+//        }
+//    }
+//
+//    private static func data(for record: SwappedRecord) -> Data? {
+//        let encoder = JSONEncoder()
+//        encoder.outputFormatting = .prettyPrinted
+//        guard let data = try? encoder.encode(record) else { return nil }
+//        return data
+//    }
+//
+//    private static func record(with data: Data) -> SwappedRecord? {
+//        let decoder = JSONDecoder()
+//        guard let record = try? decoder.decode(SwappedRecord.self, from: data) else { return nil }
+//        return record
+//    }
+//
+//}

--- a/Cauli/Florets/Mock/SwappedRecord.swift
+++ b/Cauli/Florets/Mock/SwappedRecord.swift
@@ -22,55 +22,55 @@
 
 import Foundation
 
-internal struct SwappedRecord: Codable {
-    let identifier: UUID
-    let originalRequest: SwappedURLRequest
-    let designatedRequest: SwappedURLRequest
-    let result: Result<SwappedResponse>?
-    let requestStarted: Date?
-    let responseReceived: Date?
-}
-
-extension SwappedRecord {
-    init(_ record: Record, folder: URL) {
-        self.identifier = record.identifier
-        self.originalRequest = SwappedURLRequest(record.originalRequest, bodyFilepath: folder.appendingPathComponent("originalRequest.data"))
-        self.designatedRequest = SwappedURLRequest(record.designatedRequest, bodyFilepath: folder.appendingPathComponent("designatedRequest.data"))
-        if let result = record.result {
-            switch result {
-            case .error(let error):
-                self.result = .error(error)
-            case .result(let response):
-                let swappedResponse = SwappedResponse(response, dataFilepath: folder.appendingPathComponent("response.data"))
-                self.result = .result(swappedResponse)
-            }
-        } else {
-            self.result = nil
-        }
-
-        self.requestStarted = record.requestStarted
-        self.responseReceived = record.responseReceived
-    }
-
-    func record(in folder: URL) -> Record {
-        var record = Record(self.originalRequest.urlRequest(in: folder))
-
-        record.identifier = self.identifier
-        record.designatedRequest = self.designatedRequest.urlRequest(in: folder)
-        if let result = self.result {
-            switch result {
-            case .error(let error):
-                record.result = .error(error)
-            case .result(let swappedResponse):
-                let response = swappedResponse.response(in: folder)
-                record.result = .result(response)
-            }
-        } else {
-            record.result = nil
-        }
-        record.requestStarted = self.requestStarted
-        record.responseReceived = self.responseReceived
-
-        return record
-    }
-}
+//internal struct SwappedRecord: Codable {
+//    let identifier: UUID
+//    let originalRequest: SwappedURLRequest
+//    let designatedRequest: SwappedURLRequest
+//    let result: Result<SwappedResponse>?
+//    let requestStarted: Date?
+//    let responseReceived: Date?
+//}
+//
+//extension SwappedRecord {
+//    init(_ record: Record, folder: URL) {
+//        self.identifier = record.identifier
+//        self.originalRequest = SwappedURLRequest(record.originalRequest, bodyFilepath: folder.appendingPathComponent("originalRequest.data"))
+//        self.designatedRequest = SwappedURLRequest(record.designatedRequest, bodyFilepath: folder.appendingPathComponent("designatedRequest.data"))
+//        if let result = record.result {
+//            switch result {
+//            case .error(let error):
+//                self.result = .error(error)
+//            case .result(let response):
+//                let swappedResponse = SwappedResponse(response, dataFilepath: folder.appendingPathComponent("response.data"))
+//                self.result = .result(swappedResponse)
+//            }
+//        } else {
+//            self.result = nil
+//        }
+//
+//        self.requestStarted = record.requestStarted
+//        self.responseReceived = record.responseReceived
+//    }
+//
+//    func record(in folder: URL) -> Record {
+//        var record = Record(self.originalRequest.urlRequest(in: folder))
+//
+//        record.identifier = self.identifier
+//        record.designatedRequest = self.designatedRequest.urlRequest(in: folder)
+//        if let result = self.result {
+//            switch result {
+//            case .error(let error):
+//                record.result = .error(error)
+//            case .result(let swappedResponse):
+//                let response = swappedResponse.response(in: folder)
+//                record.result = .result(response)
+//            }
+//        } else {
+//            record.result = nil
+//        }
+//        record.requestStarted = self.requestStarted
+//        record.responseReceived = self.responseReceived
+//
+//        return record
+//    }
+//}

--- a/Cauli/Florets/Mock/SwappedResponse.swift
+++ b/Cauli/Florets/Mock/SwappedResponse.swift
@@ -22,46 +22,46 @@
 
 import Foundation
 
-internal struct SwappedResponse: Codable {
-    let dataFilename: String?
-    var urlResponse: URLResponse {
-        get {
-            return urlResponseRepresentable.urlResponse
-        }
-        set {
-            urlResponseRepresentable = URLResponseRepresentable(newValue)
-        }
-    }
-
-    init(_ urlResponse: URLResponse, dataFilename: String?) {
-        self.dataFilename = dataFilename
-        urlResponseRepresentable = URLResponseRepresentable(urlResponse)
-    }
-
-    var urlResponseRepresentable: URLResponseRepresentable
-}
-
-extension SwappedResponse {
-    init(_ response: Response, dataFilepath: URL) {
-        self.urlResponseRepresentable = URLResponseRepresentable(response.urlResponse)
-
-        if let data = response.data,
-            (try? data.write(to: dataFilepath)) != nil {
-            self.dataFilename = dataFilepath.lastPathComponent
-        } else {
-            self.dataFilename = nil
-        }
-    }
-
-    func response(in folder: URL) -> Response {
-        var response = Response(urlResponse, data: nil)
-        response.data = nil
-
-        if let dataFilename = dataFilename,
-            let data = try? Data(contentsOf: folder.appendingPathComponent(dataFilename)) {
-            response.data = data
-        }
-
-        return response
-    }
-}
+//internal struct SwappedResponse: Codable {
+//    let dataFilename: String?
+//    var urlResponse: URLResponse {
+//        get {
+//            return urlResponseRepresentable.urlResponse
+//        }
+//        set {
+//            urlResponseRepresentable = URLResponseRepresentable(newValue)
+//        }
+//    }
+//
+//    init(_ urlResponse: URLResponse, dataFilename: String?) {
+//        self.dataFilename = dataFilename
+//        urlResponseRepresentable = URLResponseRepresentable(urlResponse)
+//    }
+//
+//    var urlResponseRepresentable: URLResponseRepresentable
+//}
+//
+//extension SwappedResponse {
+//    init(_ response: Response, dataFilepath: URL) {
+//        self.urlResponseRepresentable = URLResponseRepresentable(response.urlResponse)
+//
+//        if let data = response.data,
+//            (try? data.write(to: dataFilepath)) != nil {
+//            self.dataFilename = dataFilepath.lastPathComponent
+//        } else {
+//            self.dataFilename = nil
+//        }
+//    }
+//
+//    func response(in folder: URL) -> Response {
+//        var response = Response(urlResponse, data: nil)
+//        response.data = nil
+//
+//        if let dataFilename = dataFilename,
+//            let data = try? Data(contentsOf: folder.appendingPathComponent(dataFilename)) {
+//            response.data = data
+//        }
+//
+//        return response
+//    }
+//}

--- a/Cauli/Florets/NoCache/NoCacheFloret.swift
+++ b/Cauli/Florets/NoCache/NoCacheFloret.swift
@@ -40,7 +40,7 @@ public class NoCacheFloret: FindReplaceFloret {
 
     /// Public initalizer to create an instance of the `NoCacheFloret`.
     public required init() {
-        let willRequestReplaceDefinition = RecordModifier(keyPath: \Record.designatedRequest) { designatedRequest -> (URLRequest) in
+        let willRequestReplaceDefinition = RecordModifier(keyPath: \Record.request) { designatedRequest -> (URLRequest) in
             var request = designatedRequest
             request.cachePolicy = URLRequest.CachePolicy.reloadIgnoringLocalCacheData
             request.setValue(nil, forHTTPHeaderField: "If-Modified-Since")
@@ -61,7 +61,9 @@ public class NoCacheFloret: FindReplaceFloret {
 
             guard let newHTTPURLRespones = HTTPURLResponse(url: url, statusCode: httpURLResponse.statusCode, httpVersion: nil, headerFields: allHTTPHeaderFields) else { return result }
 
-            return Result.result(Response(newHTTPURLRespones, data: response.data))
+            // TODO: Fixme
+            return Result.result(Response(newHTTPURLRespones, responseBodyStream: nil))
+//            return Result.result(Response(newHTTPURLRespones, data: response.data))
         }
 
         super.init(willRequestModifiers: [willRequestReplaceDefinition], didRespondModifiers: [didRespondReplaceDefinition], name: "NoCacheFloret")

--- a/Cauli/MemoryStorage.swift
+++ b/Cauli/MemoryStorage.swift
@@ -22,50 +22,50 @@
 
 import Foundation
 
-internal final class MemoryStorage: Storage {
-
-    var records: [Record] = []
-    var capacity: StorageCapacity {
-        didSet {
-            ensureCapacity()
-        }
-    }
-    var preStorageRecordModifier: RecordModifier?
-
-    init(capacity: StorageCapacity, preStorageRecordModifier: RecordModifier? = nil) {
-        self.capacity = capacity
-        self.preStorageRecordModifier = preStorageRecordModifier
-    }
-
-    func store(_ record: Record) {
-        assert(Thread.isMainThread, "\(#file):\(#line) must run on the main thread!")
-        let modifiedRecord = preStorageRecordModifier?.modify(record) ?? record
-        if let recordIndex = records.index(where: { $0.identifier == modifiedRecord.identifier }) {
-            records[recordIndex] = modifiedRecord
-        } else {
-            records.insert(modifiedRecord, at: 0)
-            ensureCapacity()
-        }
-    }
-
-    func records(_ count: Int, after record: Record?) -> [Record] {
-        assert(Thread.isMainThread, "\(#file):\(#line) must run on the main thread!")
-        let index: Int
-        if let record = record,
-            let recordIndex = records.index(where: { $0.identifier == record.identifier }) {
-            index = recordIndex + 1
-        } else {
-            index = 0
-        }
-        let maxCount = min(count, records.count - index)
-        return Array(records[index..<(index + maxCount)])
-    }
-
-    private func ensureCapacity() {
-        switch capacity {
-        case .unlimited: return
-        case .records(let maximumRecordCount):
-            records = Array(records.prefix(maximumRecordCount))
-        }
-    }
-}
+//internal final class MemoryStorage: Storage {
+//
+//    var records: [Record] = []
+//    var capacity: StorageCapacity {
+//        didSet {
+//            ensureCapacity()
+//        }
+//    }
+//    var preStorageRecordModifier: RecordModifier?
+//
+//    init(capacity: StorageCapacity, preStorageRecordModifier: RecordModifier? = nil) {
+//        self.capacity = capacity
+//        self.preStorageRecordModifier = preStorageRecordModifier
+//    }
+//
+//    func store(_ record: Record) {
+//        assert(Thread.isMainThread, "\(#file):\(#line) must run on the main thread!")
+//        let modifiedRecord = preStorageRecordModifier?.modify(record) ?? record
+//        if let recordIndex = records.index(where: { $0.identifier == modifiedRecord.identifier }) {
+//            records[recordIndex] = modifiedRecord
+//        } else {
+//            records.insert(modifiedRecord, at: 0)
+//            ensureCapacity()
+//        }
+//    }
+//
+//    func records(_ count: Int, after record: Record?) -> [Record] {
+//        assert(Thread.isMainThread, "\(#file):\(#line) must run on the main thread!")
+//        let index: Int
+//        if let record = record,
+//            let recordIndex = records.index(where: { $0.identifier == record.identifier }) {
+//            index = recordIndex + 1
+//        } else {
+//            index = 0
+//        }
+//        let maxCount = min(count, records.count - index)
+//        return Array(records[index..<(index + maxCount)])
+//    }
+//
+//    private func ensureCapacity() {
+//        switch capacity {
+//        case .unlimited: return
+//        case .records(let maximumRecordCount):
+//            records = Array(records.prefix(maximumRecordCount))
+//        }
+//    }
+//}

--- a/Cauli/RecordModifier.swift
+++ b/Cauli/RecordModifier.swift
@@ -55,7 +55,7 @@ extension RecordModifier {
     ///   - template: The substitution template used when replacing matching instances of the expression.
     /// - Returns: A RecordModifier is modifying the RequestURL. Used to initalize a FindReplaceFloret.
     public static func modifyUrl(expression: NSRegularExpression, template: String) -> RecordModifier {
-        let keyPath = \Record.designatedRequest.url
+        let keyPath = \Record.request.url
         let modifier: (URL?) -> (URL?) = { url in
             guard let oldURL = url else { return url }
             let urlWithReplacements = replacingOcurrences(of: expression, in: oldURL.absoluteString, with: template)

--- a/Cauli/Storage.swift
+++ b/Cauli/Storage.swift
@@ -24,37 +24,58 @@ import Foundation
 
 /// A Storage is used to store and retrieve Records. It can be either in memory or on disk.
 public protocol Storage {
-
+    
     /// The `capacity` defines the capacity of the storage.
     var capacity: StorageCapacity { get set }
-
+    
     /// A `RecordModifier` that can modify each `Record` before it is persisted to a `Storage`.
     /// This allows you to modify requests and responses after they are executed but before they are passed along to other florets.
     var preStorageRecordModifier: RecordModifier? { get set }
-
-    /// Initialize a Store with capacity and optional pre storage record modifier
-    ///
-    /// - Parameters:
-    ///   - capacity: `StorageCapacity` of the storage
-    ///   - preStorageRecordModifier: `RecordModifier` that can modify a `Record` before it is stored
-    init(capacity: StorageCapacity, preStorageRecordModifier: RecordModifier?)
-
+    
     /// Adds a record to the storage. Updates a possibly existing record.
     /// A record is the same if it's identifier is the same.
     ///
     /// - Parameter record: The record to add to the storage.
     func store(_ record: Record)
-
+    
     /// Returns a number of records after the referenced record.
-    /// Records are sorted by order there were added to the storage,
-    /// Might return less than `count` if there are no more records.
     ///
     /// - Parameters:
-    ///   - count: The number of records that should be returned.
+    ///   - predicate: An optional predicate to filter the records
+    ///   - sorting: A sort descriptor defining the order of the returned items
+    ///   - limit: The maximum number of records that should be returned.
     ///   - after: The record after which there should be new records returned.
-    /// - Returns: The records after the referenced record, sorted from latest to oldest.
-    func records(_ count: Int, after: Record?) -> [Record]
+    ///         If nil, the first records are returned
+    /// - Returns: The records after the referenced record.
+    func records<T: Comparable>(with predicate: NSPredicate?, sortedBy keyPath: KeyPath<Record, T?>, ascending: Bool, limit: Int, after record: Record?) -> [Record]
+    
+    /// Stores the request body data as a stream.
+    ///
+    /// - Parameters:
+    ///   - stream: The stream to store.
+    ///   - record: The record describing the request.
+    func storeRequestBody(_ stream: InputStream, for record: Record)
+    
+    /// Returns the request body data as a stream.
+    ///
+    /// - Parameter record: The record describing the request.
+    /// - Returns: The inputStream for the data if any was stored before.
+    func requestBody(for record: Record) -> InputStream?
+    
+    /// Stores the response body data as a stream.
+    ///
+    /// - Parameters:
+    ///   - stream: The stream to store.
+    ///   - record: The record describing the request.
+    func storeResponseBody(_ stream: InputStream, for record: Record)
+    
+    /// Returns the response body data as a stream.
+    ///
+    /// - Parameter record: The record describing the request.
+    /// - Returns: The inputStream for the data if any was stored before.
+    func responseBody(for record: Record) -> InputStream?
 }
+
 
 /// Defines the capacity of a storage.
 public enum StorageCapacity: Equatable {

--- a/Cauli/Storage.swift
+++ b/Cauli/Storage.swift
@@ -48,32 +48,6 @@ public protocol Storage {
     ///         If nil, the first records are returned
     /// - Returns: The records after the referenced record.
     func records<T: Comparable>(with predicate: NSPredicate?, sortedBy keyPath: KeyPath<Record, T?>, ascending: Bool, limit: Int, after record: Record?) -> [Record]
-
-    /// Stores the request body data as a stream.
-    ///
-    /// - Parameters:
-    ///   - stream: The stream to store.
-    ///   - record: The record describing the request.
-    func storeRequestBody(_ stream: InputStream, for record: Record)
-
-    /// Returns the request body data as a stream.
-    ///
-    /// - Parameter record: The record describing the request.
-    /// - Returns: The inputStream for the data if any was stored before.
-    func requestBody(for record: Record) -> InputStream?
-
-    /// Stores the response body data as a stream.
-    ///
-    /// - Parameters:
-    ///   - stream: The stream to store.
-    ///   - record: The record describing the request.
-    func storeResponseBody(_ stream: InputStream, for record: Record)
-
-    /// Returns the response body data as a stream.
-    ///
-    /// - Parameter record: The record describing the request.
-    /// - Returns: The inputStream for the data if any was stored before.
-    func responseBody(for record: Record) -> InputStream?
 }
 
 /// Defines the capacity of a storage.

--- a/Cauli/Storage.swift
+++ b/Cauli/Storage.swift
@@ -24,20 +24,20 @@ import Foundation
 
 /// A Storage is used to store and retrieve Records. It can be either in memory or on disk.
 public protocol Storage {
-    
+
     /// The `capacity` defines the capacity of the storage.
     var capacity: StorageCapacity { get set }
-    
+
     /// A `RecordModifier` that can modify each `Record` before it is persisted to a `Storage`.
     /// This allows you to modify requests and responses after they are executed but before they are passed along to other florets.
     var preStorageRecordModifier: RecordModifier? { get set }
-    
+
     /// Adds a record to the storage. Updates a possibly existing record.
     /// A record is the same if it's identifier is the same.
     ///
     /// - Parameter record: The record to add to the storage.
     func store(_ record: Record)
-    
+
     /// Returns a number of records after the referenced record.
     ///
     /// - Parameters:
@@ -48,34 +48,33 @@ public protocol Storage {
     ///         If nil, the first records are returned
     /// - Returns: The records after the referenced record.
     func records<T: Comparable>(with predicate: NSPredicate?, sortedBy keyPath: KeyPath<Record, T?>, ascending: Bool, limit: Int, after record: Record?) -> [Record]
-    
+
     /// Stores the request body data as a stream.
     ///
     /// - Parameters:
     ///   - stream: The stream to store.
     ///   - record: The record describing the request.
     func storeRequestBody(_ stream: InputStream, for record: Record)
-    
+
     /// Returns the request body data as a stream.
     ///
     /// - Parameter record: The record describing the request.
     /// - Returns: The inputStream for the data if any was stored before.
     func requestBody(for record: Record) -> InputStream?
-    
+
     /// Stores the response body data as a stream.
     ///
     /// - Parameters:
     ///   - stream: The stream to store.
     ///   - record: The record describing the request.
     func storeResponseBody(_ stream: InputStream, for record: Record)
-    
+
     /// Returns the response body data as a stream.
     ///
     /// - Parameter record: The record describing the request.
     /// - Returns: The inputStream for the data if any was stored before.
     func responseBody(for record: Record) -> InputStream?
 }
-
 
 /// Defines the capacity of a storage.
 public enum StorageCapacity: Equatable {


### PR DESCRIPTION
This PR updates the `Storage` protocol and the `Record` to match the new concept and comments out all code that is outdated.

In comparison to the concept, the API to store the request and response data was a bit changed. Since the Record now has references to the requestBodyStream and the responseBodyStream, the storage implementation can extract the streams, store them separately and re-add them later.