### PR TITLE
Set the version number project wide

### DIFF
--- a/Cauliframework.xcodeproj/project.pbxproj
+++ b/Cauliframework.xcodeproj/project.pbxproj
@@ -809,6 +809,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -865,6 +866,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -893,7 +895,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -919,7 +920,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = works.cauli.cauliframework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -937,7 +937,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = works.cauli.CauliframeworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -955,7 +954,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = works.cauli.CauliframeworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Package.swift
+++ b/Package.swift
@@ -13,5 +13,5 @@ let package = Package(
     targets: [
         .target(name: "Cauliframework", dependencies: [], path: "Cauli"),
     ],
-   swiftLanguageVersions:[.v5]
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
It's easier to maintain if all target have the same swift version.

Actually the swift version for the framework target was set to 5, and for the testing target to 4.2, which was not intended, I think. To avoid this it's better having to change this only once. 