### PR TITLE
Specify the spm platform to support only iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ import PackageDescription
 
 let package = Package(
     name: "Cauliframework",
+    platforms: [
+        .iOS(.v8),
+    ],
     products: [
         .library(name: "Cauliframework", targets: ["Cauliframework"])
     ],


### PR DESCRIPTION
Currently macOS is not supported since Cauli uses UIKit. So we need to specify the supported platform.