### PR TITLE
Revert color back to default after string.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,5 +66,5 @@ def tests_failed(platform)
 end
 
 def red(string)
-  "\033[0;31m! #{string}"
+  "\033[0;31m! #{string}\033[0m"
 end


### PR DESCRIPTION
Everything after the string got printed in red. Even in another print statement.