### PR TITLE
Added an URLRequest extension to generate cURL commands

### DIFF
--- a/Cauli/Extensions/URLRequest+CURL.swift
+++ b/Cauli/Extensions/URLRequest+CURL.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) 2021 cauli.works
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension URLRequest {
+
+    var cURL: String {
+        ""
+    }
+
+}

--- a/Cauli/Extensions/URLRequest+CURL.swift
+++ b/Cauli/Extensions/URLRequest+CURL.swift
@@ -25,7 +25,38 @@ import Foundation
 extension URLRequest {
 
     var cURL: String {
-        ""
+        guard let url = url,
+              let httpMethod = httpMethod else {
+            assertionFailure("")
+            return ""
+        }
+
+        var options: [String] = ["-X \(httpMethod)"]
+
+        if let httpHeaderFields = allHTTPHeaderFields,
+           !httpHeaderFields.isEmpty {
+            let combinedHeaders = httpHeaderFields.reduce("") { result, httpHeaderField -> String in
+                var mutableResult = result
+                mutableResult += "-H \"\(httpHeaderField.key): \(httpHeaderField.value)\""
+                return mutableResult
+            }
+            options.append(combinedHeaders)
+        }
+
+        if let httpBody = httpBody,
+           let httpBodyString = String(data: httpBody, encoding: .utf8),
+           !httpBodyString.isEmpty {
+            options.append("-d \"\(httpBodyString)\"")
+        }
+
+        let commandParts = ["curl",
+                            options.joined(separator: " "),
+                            url.absoluteString]
+        return commandParts.compactMap {
+            guard !$0.isEmpty else { return nil }
+            return $0
+        }
+        .joined(separator: " ")
     }
 
 }

--- a/CauliTests/Fakes/URLRequest+Fake.swift
+++ b/CauliTests/Fakes/URLRequest+Fake.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) 2021 cauli.works
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension URLRequest {
+    
+    static var fake: URLRequest {
+        return URLRequest(url: URL(string: "https://cauli.works/fake")!)
+    }
+    
+}

--- a/CauliTests/Fakes/URLRequest+Fake.swift
+++ b/CauliTests/Fakes/URLRequest+Fake.swift
@@ -24,8 +24,24 @@ import Foundation
 
 extension URLRequest {
     
-    static var fake: URLRequest {
-        return URLRequest(url: URL(string: "https://cauli.works/fake")!)
+    static func fake(httpMethod: String? = nil, httpHeaders: [String: String]? = nil, httpBody: String? = nil) -> URLRequest{
+        var request = URLRequest(url: URL(string: "https://cauli.works/fake")!)
+        
+        if let httpMethod = httpMethod {
+            request.httpMethod = httpMethod
+        }
+        
+        if let httpHeaders = httpHeaders {
+            httpHeaders.forEach {
+                request.addValue($0.value, forHTTPHeaderField: $0.key)
+            }
+        }
+        
+        if let httpBody = httpBody {
+            request.httpBody = httpBody.data(using: .utf8)
+        }
+        
+        return request
     }
     
 }

--- a/CauliTests/URLRequest+CURLSpec.swift
+++ b/CauliTests/URLRequest+CURLSpec.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) 2021 cauli.works
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+
+@testable import Cauliframework
+import Foundation
+import Quick
+import Nimble
+
+class URLRequestCURLSpec: QuickSpec {
+    
+    override func spec() {
+        describe("cURL") {
+            it("should return") {
+                let fakeRequest = URLRequest.fake
+                expect(fakeRequest.cURL) == ""
+            }
+        }
+    }
+    
+}

--- a/CauliTests/URLRequest+CURLSpec.swift
+++ b/CauliTests/URLRequest+CURLSpec.swift
@@ -30,9 +30,43 @@ class URLRequestCURLSpec: QuickSpec {
     
     override func spec() {
         describe("cURL") {
-            it("should return") {
-                let fakeRequest = URLRequest.fake
-                expect(fakeRequest.cURL) == ""
+            it("returns a curl command with http method and URL") {
+                let fakeRequest = URLRequest.fake()
+                expect(fakeRequest.cURL) == "curl -X GET https://cauli.works/fake"
+            }
+            
+            it("starts with curl as prefix") {
+                let fakeRequest = URLRequest.fake()
+                let hasCurlAsPrefix = fakeRequest.cURL.hasPrefix("curl")
+                expect(hasCurlAsPrefix) == true
+            }
+            
+            it("returns a curl command matching the request URL") {
+                let fakeRequest = URLRequest.fake()
+                let hasURLasSuffix = fakeRequest.cURL.hasSuffix("https://cauli.works/fake")
+                expect(hasURLasSuffix) == true
+            }
+            
+            it("ensures to contain the request http method") {
+                let httpMethod = "POST"
+                let fakeRequest = URLRequest.fake(httpMethod: httpMethod)
+                let containsRequestMethodPost = fakeRequest.cURL.contains("-X \(httpMethod)")
+                expect(containsRequestMethodPost) == true
+            }
+            
+            it("ensures to contain the http header fields") {
+                let httpHeaders = ["Accept": "application/json", "Content-Type": "text/xml"]
+                let fakeRequest = URLRequest.fake(httpHeaders: httpHeaders)
+                let containsAcceptHTTPHeader = fakeRequest.cURL.contains("-H \"Accept: application/json\"")
+                let containsContentTypeHTTPHeader = fakeRequest.cURL.contains("-H \"Content-Type: text/xml\"")
+                expect(containsAcceptHTTPHeader && containsContentTypeHTTPHeader) == true
+            }
+            
+            it("ensures to contain the http body data") {
+                let httpBody = "{ \"http\": \"body\" }"
+                let fakeRequest = URLRequest.fake(httpBody: httpBody)
+                let containsHttpBody = fakeRequest.cURL.contains("-d \"\(httpBody)\"")
+                expect(containsHttpBody) == true
             }
         }
     }

--- a/Cauliframework.xcodeproj/project.pbxproj
+++ b/Cauliframework.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		50A6CFB821178E2200FC57E7 /* URLRequest+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A6CFB721178E2200FC57E7 /* URLRequest+Codable.swift */; };
 		50ABECFF21C834A5009667E1 /* FindReplaceFloretSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50ABECFE21C834A5009667E1 /* FindReplaceFloretSpec.swift */; };
 		50B6C944212DF2D500BB1E57 /* NSError+Cauli.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */; };
+		50B71F4825FE266400D58460 /* URLRequest+CURLSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B71F4725FE266400D58460 /* URLRequest+CURLSpec.swift */; };
+		50B71F4E25FE26D500D58460 /* URLRequest+Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B71F4D25FE26D500D58460 /* URLRequest+Fake.swift */; };
+		50B71F5425FE26F000D58460 /* URLRequest+CURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B71F5325FE26F000D58460 /* URLRequest+CURL.swift */; };
 		50E068E821C67E0C00A9DFA8 /* FindReplaceFloret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E068E721C67E0C00A9DFA8 /* FindReplaceFloret.swift */; };
 		50E068EA21C67E2300A9DFA8 /* RecordModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E068E921C67E2300A9DFA8 /* RecordModifier.swift */; };
 		6267C31F023357615618E5CD /* Pods_Cauliframework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E132CF77DE7DED9DD5287C2E /* Pods_Cauliframework.framework */; };
@@ -162,6 +165,9 @@
 		50A6CFB721178E2200FC57E7 /* URLRequest+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Codable.swift"; sourceTree = "<group>"; };
 		50ABECFE21C834A5009667E1 /* FindReplaceFloretSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindReplaceFloretSpec.swift; sourceTree = "<group>"; };
 		50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Cauli.swift"; sourceTree = "<group>"; };
+		50B71F4725FE266400D58460 /* URLRequest+CURLSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+CURLSpec.swift"; sourceTree = "<group>"; };
+		50B71F4D25FE26D500D58460 /* URLRequest+Fake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+Fake.swift"; sourceTree = "<group>"; };
+		50B71F5325FE26F000D58460 /* URLRequest+CURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+CURL.swift"; sourceTree = "<group>"; };
 		50E068E721C67E0C00A9DFA8 /* FindReplaceFloret.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindReplaceFloret.swift; sourceTree = "<group>"; };
 		50E068E921C67E2300A9DFA8 /* RecordModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordModifier.swift; sourceTree = "<group>"; };
 		6150F830B00ACA8197E38F4A /* Pods_Cauli.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Cauli.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -353,6 +359,7 @@
 				1F7001C0216B8128007A9355 /* CauliURLProtocolSpec.swift */,
 				1FFFE7D221AC7C080040B805 /* MemoryStorageSpec.swift */,
 				505B4BED21AC5BF1008A9836 /* URLResponseRepresentableSpec.swift */,
+				50B71F4725FE266400D58460 /* URLRequest+CURLSpec.swift */,
 				1F8C2A1421D794BD009D0382 /* CauliSpec.swift */,
 				50ABECFE21C834A5009667E1 /* FindReplaceFloretSpec.swift */,
 				5044B7E921F28555006908B2 /* NoCacheFloretSpec.swift */,
@@ -366,6 +373,7 @@
 				1FFFE7D121AC7C080040B805 /* Record+Fake.swift */,
 				50A53E4921B1799000DCB517 /* HTTPURLResponse+Fake.swift */,
 				50A53E4A21B1799000DCB517 /* URLResponse+Fake.swift */,
+				50B71F4D25FE26D500D58460 /* URLRequest+Fake.swift */,
 			);
 			path = Fakes;
 			sourceTree = "<group>";
@@ -448,6 +456,7 @@
 			children = (
 				1F7BF22F20F790F50023D219 /* URLSessionConfiguration+Swizzling.swift */,
 				50A6CFB721178E2200FC57E7 /* URLRequest+Codable.swift */,
+				50B71F5325FE26F000D58460 /* URLRequest+CURL.swift */,
 				5087DE9D21331041005B7080 /* NSError+Codable.swift */,
 				1FB1FF55219DB75E0021B4F4 /* UIWindow+Shake.swift */,
 				50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */,
@@ -686,6 +695,7 @@
 				1FF25CF92275EDD800008E51 /* NSError+NetworkErrorShortString.swift in Sources */,
 				1FA4A50A21B7C40100F1CA6B /* RecordItemTableViewCell.swift in Sources */,
 				1FA4A50E21B7C40100F1CA6B /* InspectorTableViewController.swift in Sources */,
+				50B71F5425FE26F000D58460 /* URLRequest+CURL.swift in Sources */,
 				1F0ACDFF222C26D0004E0361 /* PlaintextPrettyPrinter.swift in Sources */,
 				1F0EB9E3219DB4C800060F28 /* MockRecordSerializer.swift in Sources */,
 				50A6CFB821178E2200FC57E7 /* URLRequest+Codable.swift in Sources */,
@@ -729,9 +739,11 @@
 			files = (
 				1FFFE7D621AC7C080040B805 /* Record+Fake.swift in Sources */,
 				50A53E4B21B1799000DCB517 /* HTTPURLResponse+Fake.swift in Sources */,
+				50B71F4825FE266400D58460 /* URLRequest+CURLSpec.swift in Sources */,
 				1F7001C4216B8250007A9355 /* CauliURLProtocolDelegateStub.swift in Sources */,
 				505B4BF121AC5C91008A9836 /* URLResponse+Fake.swift in Sources */,
 				1F8C2A1521D794BD009D0382 /* CauliSpec.swift in Sources */,
+				50B71F4E25FE26D500D58460 /* URLRequest+Fake.swift in Sources */,
 				505B4BEE21AC5BF1008A9836 /* URLResponseRepresentableSpec.swift in Sources */,
 				1F7001C1216B8128007A9355 /* CauliURLProtocolSpec.swift in Sources */,
 				50ABECFF21C834A5009667E1 /* FindReplaceFloretSpec.swift in Sources */,


### PR DESCRIPTION
This PR adds an extension for URLRequest to transform a request to a cURL command. So far the cURL extension is not hooked up to any UI component since I'm not sure where this would fit the best. I'm open for any input on this one!

What do you think adding a `copy as cURL` functionality on this screen? Maybe even just as an UIActivity to the UIActivityViewController.
<img width="598" alt="Screenshot 2021-03-14 at 14 04 55" src="https://user-images.githubusercontent.com/693778/111069643-52126a00-84ce-11eb-8eff-69c70661d891.png">
