### PR TITLE
Extracted an InspectorFloretFormatter to customize the InspectorFloret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * **feature** Added a `MapRemoteFloret` that can change urls of requests before they are sent. [#216](https://github.com/cauliframework/cauli/issues/216) by @brototyp
 * **improvement** Added an optional description to florets [#176](https://github.com/cauliframework/cauli/issues/176) by @Shukuyen  
 * **improvement** Removed Cocoapods as a developer dependency in favor of SPM. [#238](https://github.com/cauliframework/cauli/pull/238)
+* **improvement** Extracted the `InspectorFloretFormatter` to increase customizability if the `InspectorFloret`. [#239](https://github.com/cauliframework/cauli/pull/239)
 * **bugfix** Fixed an issue where cauli didn’t pass the redirection information up to the application. [#196](https://github.com/cauliframework/cauli/issues/196)
 * **bugfix** Fixed an issue when using Cauli via SPM. [#238](https://github.com/cauliframework/cauli/pull/238)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,6 @@ Somebody will add two eyes to your code and might give some feedback. Got some c
 
 Checked out the repository and would like some guidance to find your way?
 
-* We are using Cocoapods to manage our two testing dependencies, [Quick](https://github.com/Quick/Quick) and [Nimble](https://github.com/Quick/Nimble).
+* We are using SPM to manage our testing dependencies, [Quick](https://github.com/Quick/Quick), [Nimble](https://github.com/Quick/Nimble) and OHHTTPStubs.
 * Just open the `Cauliframework.xcworkspace`. Here you can find all the code that make up Cauli.
 * Have you seen the `Example` folder? In there we added an iOS example application. Open the `cauli-ios-example.xcworkspace` and have a look. You can use the example app to play around, test your changes or sketch out a new idea for a Floret.

--- a/Cauli/Cauli.swift
+++ b/Cauli/Cauli.swift
@@ -40,7 +40,7 @@ public class Cauli {
     }
     private let configuration: Configuration
     private var viewControllerManager: ViewControllerShakePresenter?
-    private var enabled: Bool = false
+    private var enabled = false
 
     deinit {
         CauliURLProtocol.remove(delegate: self)

--- a/Cauli/Extensions/NSError+Cauli.swift
+++ b/Cauli/Extensions/NSError+Cauli.swift
@@ -63,3 +63,4 @@ extension NSError {
         }
     }
 }
+// swiftlint:enable nesting

--- a/Cauli/Florets/FindReplace/FindReplaceFloret.swift
+++ b/Cauli/Florets/FindReplace/FindReplaceFloret.swift
@@ -28,7 +28,7 @@ import Foundation
 /// under a given name.
 public class FindReplaceFloret: InterceptingFloret {
 
-    public var enabled: Bool = true
+    public var enabled = true
     public let name: String
     public var description: String?
 

--- a/Cauli/Florets/HTTPBodyStreamFloret/HTTPBodyStreamFloret.swift
+++ b/Cauli/Florets/HTTPBodyStreamFloret/HTTPBodyStreamFloret.swift
@@ -31,7 +31,7 @@ public class HTTPBodyStreamFloret: InterceptingFloret {
     private static let bufferByteSize = 1024
 
     private let maximumConvertedByteSize: Int64
-    public var enabled: Bool = true
+    public var enabled = true
 
     /// Will create a new `HTTPBodyStreamFloret` instance.
     ///

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
@@ -22,16 +22,9 @@
 
 import UIKit
 
-internal class InspectorFloretFormatter: InspectorFloretFormatterType {
-
-    static let timeFormatter: DateFormatter = {
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateStyle = .none
-        timeFormatter.timeStyle = .medium
-        return timeFormatter
-    }()
-
-    func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData {
+public class InspectorFloretFormatter: InspectorFloretFormatterType {
+    public init() {}
+    public func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData {
         let method = record.designatedRequest.httpMethod ?? ""
         let path = record.designatedRequest.url?.absoluteString ?? ""
         let time: String
@@ -61,17 +54,20 @@ internal class InspectorFloretFormatter: InspectorFloretFormatterType {
         return InspectorFloret.RecordListFormattedData(method: method, path: path, time: time, status: status, statusColor: statusColor)
     }
 
-    func recordMatchesQuery(record: Record, query: String) -> Bool {
+    public func recordMatchesQuery(record: Record, query: String) -> Bool {
         guard let urlString = record.designatedRequest.url?.absoluteString else {
             return false
         }
         return urlString.range(of: query, options: String.CompareOptions.caseInsensitive) != nil
     }
+}
 
+extension InspectorFloretFormatter {
     static let greenColor = UIColor(red: 11 / 255.0, green: 176 / 255.0, blue: 61 / 255.0, alpha: 1)
     static let blueColor = UIColor(red: 74 / 255.0, green: 144 / 255.0, blue: 226 / 255.0, alpha: 1)
     static let redColor = UIColor(red: 210 / 255.0, green: 46 / 255.0, blue: 14 / 255.0, alpha: 1)
     static let grayColor = UIColor(red: 155 / 255.0, green: 155 / 255.0, blue: 155 / 255.0, alpha: 1)
+
     private func colorForHTTPStatusCode(_ statusCode: Int) -> UIColor {
         switch statusCode {
         case 0..<300: return Self.greenColor
@@ -80,4 +76,13 @@ internal class InspectorFloretFormatter: InspectorFloretFormatterType {
         default: return Self.grayColor
         }
     }
+}
+
+extension InspectorFloretFormatter {
+    static let timeFormatter: DateFormatter = {
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .medium
+        return timeFormatter
+    }()
 }

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright (c) 2018 cauli.works
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+
+internal class InspectorFloretFormatter: InspectorFloretFormatterType {
+
+    static let timeFormatter: DateFormatter = {
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .medium
+        return timeFormatter
+    }()
+
+    func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData {
+        let method = record.designatedRequest.httpMethod ?? ""
+        let path = record.designatedRequest.url?.absoluteString ?? ""
+        let time: String
+        if let requestStarted = record.requestStarted {
+            time = Self.timeFormatter.string(from: requestStarted)
+        } else {
+            time = ""
+        }
+        let status: String
+        let statusColor: UIColor
+        switch record.result {
+        case nil:
+            status = "-"
+            statusColor = Self.grayColor
+        case .error(let error)?:
+            status = error.cauli_networkErrorShortString
+            statusColor = Self.redColor
+        case .result(let response)?:
+            if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
+                status = "\(httpUrlResponse.statusCode)"
+                statusColor = colorForHTTPStatusCode(httpUrlResponse.statusCode)
+            } else {
+                status = "-"
+                statusColor = Self.grayColor
+            }
+        }
+        return InspectorFloret.RecordListFormattedData(method: method, path: path, time: time, status: status, statusColor: statusColor)
+    }
+
+    static let greenColor = UIColor(red: 11 / 255.0, green: 176 / 255.0, blue: 61 / 255.0, alpha: 1)
+    static let blueColor = UIColor(red: 74 / 255.0, green: 144 / 255.0, blue: 226 / 255.0, alpha: 1)
+    static let redColor = UIColor(red: 210 / 255.0, green: 46 / 255.0, blue: 14 / 255.0, alpha: 1)
+    static let grayColor = UIColor(red: 155 / 255.0, green: 155 / 255.0, blue: 155 / 255.0, alpha: 1)
+    private func colorForHTTPStatusCode(_ statusCode: Int) -> UIColor {
+        switch statusCode {
+        case 0..<300: return Self.greenColor
+        case 300..<400: return Self.blueColor
+        case 400..<600: return Self.redColor
+        default: return Self.grayColor
+        }
+    }
+    
+}

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatter.swift
@@ -61,6 +61,13 @@ internal class InspectorFloretFormatter: InspectorFloretFormatterType {
         return InspectorFloret.RecordListFormattedData(method: method, path: path, time: time, status: status, statusColor: statusColor)
     }
 
+    func recordMatchesQuery(record: Record, query: String) -> Bool {
+        guard let urlString = record.designatedRequest.url?.absoluteString else {
+            return false
+        }
+        return urlString.range(of: query, options: String.CompareOptions.caseInsensitive) != nil
+    }
+
     static let greenColor = UIColor(red: 11 / 255.0, green: 176 / 255.0, blue: 61 / 255.0, alpha: 1)
     static let blueColor = UIColor(red: 74 / 255.0, green: 144 / 255.0, blue: 226 / 255.0, alpha: 1)
     static let redColor = UIColor(red: 210 / 255.0, green: 46 / 255.0, blue: 14 / 255.0, alpha: 1)
@@ -73,5 +80,4 @@ internal class InspectorFloretFormatter: InspectorFloretFormatterType {
         default: return Self.grayColor
         }
     }
-    
 }

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
@@ -20,7 +20,18 @@
 //  THE SOFTWARE.
 //
 
+/// The `InspectorFloretFormatterType` is used to define how a Record is formatted when
+/// shown in the `InspectorFloret`.
 public protocol InspectorFloretFormatterType {
+    /// Returns the `RecordListFormattedData` for a `Record`.
+    /// - Parameter record: the Record
+    /// - Returns: The RecordListFormattedData
     func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData
+    /// This function is called when deciding if a `Record` should be shown with a given query,
+    /// for example when typing in a search field.
+    /// - Parameters:
+    ///   - record: The Record
+    ///   - query: The Search Query
+    /// - Returns: Return true, if the Record matches the Query.
     func recordMatchesQuery(record: Record, query: String) -> Bool
 }

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
@@ -20,32 +20,6 @@
 //  THE SOFTWARE.
 //
 
-import UIKit
-
-/// The InspectorFloret lets you browse through and share your requests and responses from within the application. Just open `Cauli`s viewController.
-///
-/// You can
-/// * browse through all stored `Records`.
-/// * inspect details of a `Record`.
-/// * share details of a `Record`.
-/// * filter `Record`s by the request URL.
-public class InspectorFloret: DisplayingFloret {
-
-    public var description: String? = "Tap to inspect network requests and responses. Data is recorded as long as Cauli is enabled."
-
-    private let formatter: InspectorFloretFormatterType
-
-    /// Public initalizer to create an instance of the `InspectorFloret`.
-    public init() {
-        self.formatter = InspectorFloretFormatter()
-    }
-
-    public init(formatter: InspectorFloretFormatterType) {
-        self.formatter = formatter
-    }
-
-    public func viewController(_ cauli: Cauli) -> UIViewController {
-        InspectorTableViewController(cauli, formatter: formatter)
-    }
-
+public protocol InspectorFloretFormatterType {
+    func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData
 }

--- a/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
+++ b/Cauli/Florets/Inspector/Formatter/InspectorFloretFormatterType.swift
@@ -22,4 +22,5 @@
 
 public protocol InspectorFloretFormatterType {
     func listFormattedData(for record: Record) -> InspectorFloret.RecordListFormattedData
+    func recordMatchesQuery(record: Record, query: String) -> Bool
 }

--- a/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
+++ b/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
@@ -38,6 +38,7 @@ extension InspectorFloret {
         /// The text color of the status label will be white.
         public let statusColor: UIColor
 
+        /// Initializes a new `RecordListFormattedData`. Parameter match property documentation
         public init(method: String, path: String, time: String, status: String, statusColor: UIColor) {
             self.method = method
             self.path = path

--- a/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
+++ b/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
@@ -22,30 +22,12 @@
 
 import UIKit
 
-/// The InspectorFloret lets you browse through and share your requests and responses from within the application. Just open `Cauli`s viewController.
-///
-/// You can
-/// * browse through all stored `Records`.
-/// * inspect details of a `Record`.
-/// * share details of a `Record`.
-/// * filter `Record`s by the request URL.
-public class InspectorFloret: DisplayingFloret {
-
-    public var description: String? = "Tap to inspect network requests and responses. Data is recorded as long as Cauli is enabled."
-
-    private let formatter: InspectorFloretFormatterType
-
-    /// Public initalizer to create an instance of the `InspectorFloret`.
-    public init() {
-        self.formatter = InspectorFloretFormatter()
+extension InspectorFloret {
+    public struct RecordListFormattedData {
+        let method: String
+        let path: String
+        let time: String
+        let status: String
+        let statusColor: UIColor
     }
-
-    public init(formatter: InspectorFloretFormatterType) {
-        self.formatter = formatter
-    }
-
-    public func viewController(_ cauli: Cauli) -> UIViewController {
-        InspectorTableViewController(cauli, formatter: formatter)
-    }
-
 }

--- a/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
+++ b/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
@@ -23,11 +23,19 @@
 import UIKit
 
 extension InspectorFloret {
+    /// The RecordListFormattedData defines the data shown
+    /// in the Record list in the InspectorFloret.
     public struct RecordListFormattedData {
+        /// The string shown in the method label
         let method: String
+        /// The string shown in the path label
         let path: String
+        /// The string shown in the time label
         let time: String
+        /// The string shown in the status label
         let status: String
+        /// The background color of the status label.
+        /// The text color of the status label will be white.
         let statusColor: UIColor
     }
 }

--- a/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
+++ b/Cauli/Florets/Inspector/Formatter/RecordListFormattedData.swift
@@ -27,15 +27,23 @@ extension InspectorFloret {
     /// in the Record list in the InspectorFloret.
     public struct RecordListFormattedData {
         /// The string shown in the method label
-        let method: String
+        public let method: String
         /// The string shown in the path label
-        let path: String
+        public let path: String
         /// The string shown in the time label
-        let time: String
+        public let time: String
         /// The string shown in the status label
-        let status: String
+        public let status: String
         /// The background color of the status label.
         /// The text color of the status label will be white.
-        let statusColor: UIColor
+        public let statusColor: UIColor
+
+        public init(method: String, path: String, time: String, status: String, statusColor: UIColor) {
+            self.method = method
+            self.path = path
+            self.time = time
+            self.status = status
+            self.statusColor = statusColor
+        }
     }
 }

--- a/Cauli/Florets/Inspector/InspectorFloret.swift
+++ b/Cauli/Florets/Inspector/InspectorFloret.swift
@@ -40,6 +40,9 @@ public class InspectorFloret: DisplayingFloret {
         self.formatter = InspectorFloretFormatter()
     }
 
+    /// Public initializer to create an instace of the `InspectorFloret` with a custom
+    /// formatter. See `InspectorFloretFormatterType` for further details.
+    /// - Parameter formatter: The `InspectorFloretFormatterType` to be used.
     public init(formatter: InspectorFloretFormatterType) {
         self.formatter = formatter
     }

--- a/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
@@ -40,7 +40,7 @@ internal class InspectorRecordTableViewCell: UITableViewCell {
         if let stringToHighlight = stringToHighlight {
             var rangeToSearch = pathString.startIndex..<pathString.endIndex
             while let matchingRange = pathString.range(of: stringToHighlight, options: String.CompareOptions.caseInsensitive, range: rangeToSearch) {
-                pathAttributedString.addAttributes([.font: UIFont.boldSystemFont(ofSize: pathLabel.font.pointSize), .foregroundColor: tintColor], range: NSRange(matchingRange, in: pathString))
+                pathAttributedString.addAttributes([.font: UIFont.boldSystemFont(ofSize: pathLabel.font.pointSize), .foregroundColor: tintColor ?? .blue], range: NSRange(matchingRange, in: pathString))
                 rangeToSearch = matchingRange.upperBound..<pathString.endIndex
             }
         }

--- a/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorRecordTableViewCell.swift
@@ -24,13 +24,6 @@ import UIKit
 
 internal class InspectorRecordTableViewCell: UITableViewCell {
 
-    static let timeFormatter: DateFormatter = {
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateStyle = .none
-        timeFormatter.timeStyle = .medium
-        return timeFormatter
-    }()
-
     static let reuseIdentifier = "InspectorRecordTableViewCell"
     static let nibName = "InspectorRecordTableViewCell"
 
@@ -39,14 +32,10 @@ internal class InspectorRecordTableViewCell: UITableViewCell {
     @IBOutlet private weak var timeLabel: UILabel!
     @IBOutlet private weak var statusCodeLabel: TagLabel!
 
-    internal func configure(with record: Record, stringToHighlight: String?) {
-        if let requestStarted = record.requestStarted {
-            timeLabel.text = InspectorRecordTableViewCell.timeFormatter.string(from: requestStarted)
-        } else {
-            timeLabel.text = ""
-        }
-        methodLabel.text = record.designatedRequest.httpMethod
-        let pathString = record.designatedRequest.url?.absoluteString ?? ""
+    internal func configure(with data: InspectorFloret.RecordListFormattedData, stringToHighlight: String?) {
+        timeLabel.text = data.time
+        methodLabel.text = data.method
+        let pathString = data.path
         let pathAttributedString = NSMutableAttributedString(string: pathString)
         if let stringToHighlight = stringToHighlight {
             var rangeToSearch = pathString.startIndex..<pathString.endIndex
@@ -56,31 +45,7 @@ internal class InspectorRecordTableViewCell: UITableViewCell {
             }
         }
         pathLabel.attributedText = pathAttributedString
-        switch record.result {
-        case nil:
-            statusCodeLabel.text = "-"
-            statusCodeLabel.backgroundColor = InspectorRecordTableViewCell.grayColor
-        case .error(let error)?:
-            statusCodeLabel.text = error.cauli_networkErrorShortString
-            statusCodeLabel.backgroundColor = InspectorRecordTableViewCell.redColor
-        case .result(let response)?:
-            if let httpUrlResponse = response.urlResponse as? HTTPURLResponse {
-                statusCodeLabel.text = "\(httpUrlResponse.statusCode)"
-                statusCodeLabel.backgroundColor = colorForHTTPStatusCode(httpUrlResponse.statusCode)
-            }
-        }
-    }
-
-    static let greenColor = UIColor(red: 11 / 255.0, green: 176 / 255.0, blue: 61 / 255.0, alpha: 1)
-    static let blueColor = UIColor(red: 74 / 255.0, green: 144 / 255.0, blue: 226 / 255.0, alpha: 1)
-    static let redColor = UIColor(red: 210 / 255.0, green: 46 / 255.0, blue: 14 / 255.0, alpha: 1)
-    static let grayColor = UIColor(red: 155 / 255.0, green: 155 / 255.0, blue: 155 / 255.0, alpha: 1)
-    private func colorForHTTPStatusCode(_ statusCode: Int) -> UIColor {
-        switch statusCode {
-        case 0..<300: return InspectorRecordTableViewCell.greenColor
-        case 300..<400: return InspectorRecordTableViewCell.blueColor
-        case 400..<600: return InspectorRecordTableViewCell.redColor
-        default: return InspectorRecordTableViewCell.grayColor
-        }
+        statusCodeLabel.text = data.status
+        statusCodeLabel.backgroundColor = data.statusColor
     }
 }

--- a/Cauli/Florets/Inspector/Record List/InspectorTableViewController.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorTableViewController.swift
@@ -27,7 +27,8 @@ internal class InspectorTableViewController: UITableViewController {
     private static let recordPageSize = 20
 
     var cauli: Cauli
-    let dataSource = InspectorTableViewDatasource()
+    let formatter: InspectorFloretFormatterType
+    lazy var dataSource = { InspectorTableViewDatasource(formatter: self.formatter) }()
 
     private lazy var searchController: UISearchController = {
         let searchController = UISearchController(searchResultsController: nil)
@@ -40,8 +41,9 @@ internal class InspectorTableViewController: UITableViewController {
         return searchController
     }()
 
-    init(_ cauli: Cauli) {
+    init(_ cauli: Cauli, formatter: InspectorFloretFormatterType) {
         self.cauli = cauli
+        self.formatter = formatter
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Cauli/Florets/Inspector/Record List/InspectorTableViewDatasource.swift
+++ b/Cauli/Florets/Inspector/Record List/InspectorTableViewDatasource.swift
@@ -41,6 +41,13 @@ internal class InspectorTableViewDatasource: NSObject {
         }
     }
 
+    private let formatter: InspectorFloretFormatterType
+
+    init(formatter: InspectorFloretFormatterType) {
+        self.formatter = formatter
+        super.init()
+    }
+
     private func filteredItems(in array: [Record], with filter: RecordSelector?) -> [Record] {
         guard let filter = filter else { return array }
         return array.filter(filter.selects)
@@ -107,7 +114,8 @@ extension InspectorTableViewDatasource: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: InspectorRecordTableViewCell.reuseIdentifier, for: indexPath) as? InspectorRecordTableViewCell else {
             fatalError("Unable to dequeue a cell")
         }
-        cell.configure(with: record(at: indexPath), stringToHighlight: filterString)
+        let data = formatter.listFormattedData(for: record(at: indexPath))
+        cell.configure(with: data, stringToHighlight: filterString)
         cell.accessoryType = .disclosureIndicator
         return cell
     }

--- a/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewController.swift
@@ -74,10 +74,11 @@ extension RecordTableViewController {
     }
 
     private func presentActionSelection(for item: RecordTableViewDatasource.Item, from cell: UITableViewCell) {
+        guard let valueGenerator = item.value else { return }
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         for prettyPrinter in RecordTableViewController.prettyPrinter {
-            if let value = item.value(), let viewController = prettyPrinter.viewController(for: value) {
+            if let viewController = prettyPrinter.viewController(for: valueGenerator()) {
                 alertController.addAction(UIAlertAction(title: prettyPrinter.name, style: .default) { [weak self] _ in
                     self?.navigationController?.pushViewController(viewController, animated: true)
                 })
@@ -85,7 +86,7 @@ extension RecordTableViewController {
         }
 
         alertController.addAction(UIAlertAction(title: "Share", style: .default) { [weak self] _ in
-            let activityItem = item.value() ?? item.description
+            let activityItem = valueGenerator()
             self?.presentShareSheet(for: [activityItem], from: cell)
         })
 

--- a/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
+++ b/Cauli/Florets/Inspector/Record/RecordTableViewDatasource.swift
@@ -97,13 +97,14 @@ extension RecordTableViewDatasource {
     }
 }
 
+// swiftlint:disable trailing_closure
 extension RecordTableViewDatasource.Item {
     init(title: String, description: String) {
         self.init(title: title, description: description, value: nil)
     }
     static func forBody(in response: Response) -> RecordTableViewDatasource.Item {
         RecordTableViewDatasource.Item(title: "Body", description: "\(response.data?.count ?? 0) bytes", value: {
-            guard let data = response.data else { return nil as URL? }
+            guard let data = response.data else { return nil as URL? as Any }
             let fileName = response.urlResponse.suggestedFilename ?? UUID().uuidString
             let tmpFolder = URL(fileURLWithPath: NSTemporaryDirectory())
             let filePath = tmpFolder.appendingPathComponent(fileName)
@@ -111,7 +112,7 @@ extension RecordTableViewDatasource.Item {
                 try data.write(to: filePath)
                 return filePath
             } catch {
-                return nil as URL?
+                return nil as URL? as Any
             }
         })
     }
@@ -123,9 +124,7 @@ extension RecordTableViewDatasource.Section {
         var requestItems: [RecordTableViewDatasource.Item] = []
         requestItems.append(RecordTableViewDatasource.Item(title: "Method", description: request.httpMethod ?? "-"))
         requestItems.append(RecordTableViewDatasource.Item(title: "URL", description: request.url?.absoluteString ?? "-"))
-        requestItems.append(RecordTableViewDatasource.Item(title: "Header Fields", description: request.allHTTPHeaderFields?.compactMap { key, value in
-            "\(key): \(value)"
-        }
+        requestItems.append(RecordTableViewDatasource.Item(title: "Header Fields", description: request.allHTTPHeaderFields?.compactMap { key, value in "\(key): \(value)" }
             .joined(separator: "\n") ?? "-", value: { request.allHTTPHeaderFields }))
         requestItems.append(RecordTableViewDatasource.Item(title: "Body", description: "\(request.httpBody?.count ?? 0) bytes", value: { request.httpBody }))
         requestItems.append(RecordTableViewDatasource.Item(title: "Cache Policy", description: String(request.cachePolicy.rawValue)))
@@ -153,3 +152,4 @@ extension RecordTableViewDatasource.Section {
     }
 
 }
+// swiftlint:enable trailing_closure

--- a/Cauli/Florets/Mock/MD5Digest.swift
+++ b/Cauli/Florets/Mock/MD5Digest.swift
@@ -187,3 +187,4 @@ private struct MD5State {
         (a, b, c, d) = (d, b &+ r, b, c)
     }
 }
+// swiftlint:enable all

--- a/Cauli/Florets/Mock/MockFloret.swift
+++ b/Cauli/Florets/Mock/MockFloret.swift
@@ -63,7 +63,7 @@ import Foundation
 /// ```
 public class MockFloret: InterceptingFloret {
 
-    public var enabled: Bool = true
+    public var enabled = true
 
     private let mode: Mode
 

--- a/Cauli/Resources/InspectorRecordTableViewCell.xib
+++ b/Cauli/Resources/InspectorRecordTableViewCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="336" height="69"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" text="200" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dwe-2a-sT2" customClass="TagLabel" customModule="Cauliframework" customModuleProvider="target">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" text="200" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dwe-2a-sT2" customClass="TagLabel" customModule="Cauliframework">
                         <rect key="frame" x="11" y="9" width="32.5" height="14.5"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32.5" id="HHo-Bu-FGN"/>

--- a/Cauliframework.xcodeproj/project.pbxproj
+++ b/Cauliframework.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		50B6C944212DF2D500BB1E57 /* NSError+Cauli.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */; };
 		50E068E821C67E0C00A9DFA8 /* FindReplaceFloret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E068E721C67E0C00A9DFA8 /* FindReplaceFloret.swift */; };
 		50E068EA21C67E2300A9DFA8 /* RecordModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E068E921C67E2300A9DFA8 /* RecordModifier.swift */; };
+		5C51E3BE2AC193F800E5720D /* InspectorFloretFormatterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51E3BB2AC193F800E5720D /* InspectorFloretFormatterType.swift */; };
+		5C51E3BF2AC193F800E5720D /* RecordListFormattedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51E3BC2AC193F800E5720D /* RecordListFormattedData.swift */; };
+		5C51E3C02AC193F800E5720D /* InspectorFloretFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51E3BD2AC193F800E5720D /* InspectorFloretFormatter.swift */; };
 		5C58F7512ABDE72A0092D5F4 /* InspectorRecordTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C58F74F2ABDE72A0092D5F4 /* InspectorRecordTableViewCell.xib */; };
 		5C58F7522ABDE72A0092D5F4 /* SwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C58F7502ABDE72A0092D5F4 /* SwitchTableViewCell.xib */; };
 		5CADABF42ABDC79400ECB901 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5CADABF32ABDC79400ECB901 /* OHHTTPStubsSwift */; };
@@ -170,6 +173,9 @@
 		50B6C943212DF2D500BB1E57 /* NSError+Cauli.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Cauli.swift"; sourceTree = "<group>"; };
 		50E068E721C67E0C00A9DFA8 /* FindReplaceFloret.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindReplaceFloret.swift; sourceTree = "<group>"; };
 		50E068E921C67E2300A9DFA8 /* RecordModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordModifier.swift; sourceTree = "<group>"; };
+		5C51E3BB2AC193F800E5720D /* InspectorFloretFormatterType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InspectorFloretFormatterType.swift; sourceTree = "<group>"; };
+		5C51E3BC2AC193F800E5720D /* RecordListFormattedData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordListFormattedData.swift; sourceTree = "<group>"; };
+		5C51E3BD2AC193F800E5720D /* InspectorFloretFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InspectorFloretFormatter.swift; sourceTree = "<group>"; };
 		5C58F74F2ABDE72A0092D5F4 /* InspectorRecordTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InspectorRecordTableViewCell.xib; sourceTree = "<group>"; };
 		5C58F7502ABDE72A0092D5F4 /* SwitchTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SwitchTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -304,6 +310,7 @@
 		1FBE790321A1A245004C81A7 /* Inspector */ = {
 			isa = PBXGroup;
 			children = (
+				5C51E3BA2AC193F800E5720D /* Formatter */,
 				1F0ACDFC222C26D0004E0361 /* PrettyPrinter */,
 				1FA4A50221B7C40100F1CA6B /* Record */,
 				1FA4A50621B7C40100F1CA6B /* Record List */,
@@ -460,6 +467,16 @@
 				50E068E721C67E0C00A9DFA8 /* FindReplaceFloret.swift */,
 			);
 			path = FindReplace;
+			sourceTree = "<group>";
+		};
+		5C51E3BA2AC193F800E5720D /* Formatter */ = {
+			isa = PBXGroup;
+			children = (
+				5C51E3BB2AC193F800E5720D /* InspectorFloretFormatterType.swift */,
+				5C51E3BC2AC193F800E5720D /* RecordListFormattedData.swift */,
+				5C51E3BD2AC193F800E5720D /* InspectorFloretFormatter.swift */,
+			);
+			path = Formatter;
 			sourceTree = "<group>";
 		};
 		5C58F74E2ABDE72A0092D5F4 /* Resources */ = {
@@ -635,6 +652,7 @@
 				1F0ACDFF222C26D0004E0361 /* PlaintextPrettyPrinter.swift in Sources */,
 				1F0EB9E3219DB4C800060F28 /* MockRecordSerializer.swift in Sources */,
 				50A6CFB821178E2200FC57E7 /* URLRequest+Codable.swift in Sources */,
+				5C51E3C02AC193F800E5720D /* InspectorFloretFormatter.swift in Sources */,
 				5044B7E821F2853A006908B2 /* NoCacheFloret.swift in Sources */,
 				1FB3296F2181CBCD001CA03D /* RecordSelector.swift in Sources */,
 				50576BBA210E173C0085DF5E /* Floret.swift in Sources */,
@@ -655,6 +673,7 @@
 				1F6BB4562163609100D56F4F /* Configuration.swift in Sources */,
 				1F7BF23020F790F50023D219 /* URLSessionConfiguration+Swizzling.swift in Sources */,
 				1F7BF22E20F77B6C0023D219 /* Record.swift in Sources */,
+				5C51E3BE2AC193F800E5720D /* InspectorFloretFormatterType.swift in Sources */,
 				1FA4A50D21B7C40100F1CA6B /* InspectorRecordTableViewCell.swift in Sources */,
 				5042C4D221EBE1B500652AC6 /* CauliViewController.swift in Sources */,
 				1F644F4A211B620B004C4271 /* WeakReference.swift in Sources */,
@@ -665,6 +684,7 @@
 				1F891AEB22271221000ECD61 /* HTTPBodyStreamFloret.swift in Sources */,
 				50B6C944212DF2D500BB1E57 /* NSError+Cauli.swift in Sources */,
 				1F95026A25F68A28006F8262 /* MappingsListViewController.swift in Sources */,
+				5C51E3BF2AC193F800E5720D /* RecordListFormattedData.swift in Sources */,
 				1F0EB9E0219DB32300060F28 /* MockFloret.swift in Sources */,
 				1F7BF22C20F77B0A0023D219 /* CauliURLProtocolDelegate.swift in Sources */,
 				5087DE9C21330018005B7080 /* URLResponseRepresentable.swift in Sources */,

--- a/Example/cauli-ios-example/cauli-ios-example.xcodeproj/project.pbxproj
+++ b/Example/cauli-ios-example/cauli-ios-example.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1FBA701E2118743E0078F6AD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1FBA701C2118743E0078F6AD /* Main.storyboard */; };
 		1FBA70202118743F0078F6AD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1FBA701F2118743F0078F6AD /* Assets.xcassets */; };
 		1FBA70232118743F0078F6AD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1FBA70212118743F0078F6AD /* LaunchScreen.storyboard */; };
+		5C51E3C22AC1CE5300E5720D /* CustomInspectorFloretFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C51E3C12AC1CE5300E5720D /* CustomInspectorFloretFormatter.swift */; };
 		5CADAC032ABDD46100ECB901 /* Cauliframework in Frameworks */ = {isa = PBXBuildFile; productRef = 5CADAC022ABDD46100ECB901 /* Cauliframework */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +36,7 @@
 		1FBA701F2118743F0078F6AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1FBA70222118743F0078F6AD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1FBA70242118743F0078F6AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5C51E3C12AC1CE5300E5720D /* CustomInspectorFloretFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInspectorFloretFormatter.swift; sourceTree = "<group>"; };
 		5C58F74D2ABDE6460092D5F4 /* cauli */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = cauli; path = ../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -106,6 +108,7 @@
 				1FBA70242118743F0078F6AD /* Info.plist */,
 				1FA4A52621C93A8700F1CA6B /* MockFloret */,
 				1F85D9C021664F850077AB81 /* Cauli+Customized.swift */,
+				5C51E3C12AC1CE5300E5720D /* CustomInspectorFloretFormatter.swift */,
 				1F45CF20221C8B8E00DA929D /* File.txt */,
 			);
 			path = "cauli-ios-example";
@@ -203,6 +206,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FBA701B2118743E0078F6AD /* RequestsTableViewController.swift in Sources */,
+				5C51E3C22AC1CE5300E5720D /* CustomInspectorFloretFormatter.swift in Sources */,
 				1FBA70192118743E0078F6AD /* AppDelegate.swift in Sources */,
 				1F2749EE21A0C13200A6DD6E /* RequestModelTableViewCell.swift in Sources */,
 				1F85D9C121664F850077AB81 /* Cauli+Customized.swift in Sources */,

--- a/Example/cauli-ios-example/cauli-ios-example/Cauli+Customized.swift
+++ b/Example/cauli-ios-example/cauli-ios-example/Cauli+Customized.swift
@@ -30,11 +30,12 @@ internal extension Cauli {
         return floret
     }()
     static let inspectorFloret = InspectorFloret()
+    static let customInspectorFloret = InspectorFloret(formatter: CustomInspectorFloretFormatter())
     static let mapRemoteFloret: MapRemoteFloret = {
         let mapping = Mapping(name: "invalidurl.invalid", sourceLocation: MappingLocation(host: "invalidurl.invalid"), destinationLocation: MappingLocation(path: "/rewritten"))
         let floret = MapRemoteFloret(mappings: [mapping])
         floret.enabled = true
         return floret
     }()
-    static let customShared = Cauli([HTTPBodyStreamFloret(), findReplaceFloret, mockFloret, inspectorFloret, mapRemoteFloret])
+    static let customShared = Cauli([HTTPBodyStreamFloret(), findReplaceFloret, mockFloret, inspectorFloret, mapRemoteFloret, customInspectorFloret])
 }

--- a/Example/cauli-ios-example/cauli-ios-example/CustomInspectorFloretFormatter.swift
+++ b/Example/cauli-ios-example/cauli-ios-example/CustomInspectorFloretFormatter.swift
@@ -1,0 +1,27 @@
+//
+//  CustomInspectorFloretFormatter.swift
+//  cauli-ios-example
+//
+//  Created by Cornelius Horstmann on 25.09.23.
+//  Copyright © 2023 brototyp.de. All rights reserved.
+//
+
+import Cauliframework
+
+class CustomInspectorFloretFormatter: InspectorFloretFormatterType {
+
+    private let defaultFormatter = InspectorFloretFormatter()
+
+    func listFormattedData(for record: Cauliframework.Record) -> Cauliframework.InspectorFloret.RecordListFormattedData {
+        guard case .error(let error) = record.result else {
+            return defaultFormatter.listFormattedData(for: record)
+        }
+        let defaultData = defaultFormatter.listFormattedData(for: record)
+        let newMethod = "\(defaultData.method) | \(error.domain).\(error.code)"
+        return Cauliframework.InspectorFloret.RecordListFormattedData(method: newMethod, path: defaultData.path, time: defaultData.time, status: defaultData.status, statusColor: defaultData.statusColor)
+    }
+
+    func recordMatchesQuery(record: Cauliframework.Record, query: String) -> Bool {
+        defaultFormatter.recordMatchesQuery(record: record, query: query)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![Cauli](https://cauli.works/logo.png)
 
 [![Tests](https://github.com/cauliframework/cauli/workflows/Tests/badge.svg)](https://github.com/cauliframework/cauli/actions)
-[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Cauliframework.svg?style=flat-square)](https://cocoapods.org/pods/Cauliframework)
+[![SPM Compatible](https://camo.githubusercontent.com/86f8561418bbd6240d5c39dbf80b83a3dc1e85e69fe58da808f0168194dcc0d3/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f5377696674504d2d436f6d70617469626c652d627269676874677265656e2e737667)](https://github.com/cauliframework/cauli/blob/develop/Package.swift)
 [![License MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/cauliframework/cauli/blob/develop/LICENSE)
 [![Jazzy documentation](https://cauli.works/docs/badge.svg)](https://cauli.works/docs/)
 


### PR DESCRIPTION
This PR extracts an `InspectorFloretFormatterType` from the `InspectorFloret`to be able to customize it. One specific use case for this is when using GraphQL for network requests. Pretty much all information in the list will be the same (everything but the data), since for GraphQL:
* All requests are POST
* Responses are always 200
* The path is always the same

With this change, one can implement a custom formatter, that shows other data in the list for GraphQL requests, for example
* Ist it a Query or a Mutation
* What is / what are the methods